### PR TITLE
Change Azure default size

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -21,7 +21,7 @@ import (
 const (
 	defaultAzureEnvironment     = "AzurePublicCloud"
 	defaultAzureResourceGroup   = "docker-machine"
-	defaultAzureSize            = "Standard_A2"
+	defaultAzureSize            = "Standard_D2_v2"
 	defaultAzureLocation        = "westus"
 	defaultSSHUser              = "docker-user" // 'root' not allowed on Azure
 	defaultDockerPort           = 2376


### PR DESCRIPTION
Problem:

The default size for RKE was Standard_A2, despite Standard_D2_v2 being recommended.

Solution:
Make Standard_D2_v2 the default Azure size, and is the same as the default size for AKS.

Issue:
https://github.com/rancher/rancher/issues/15932
