### PR TITLE
Add size to azure non-managed VMs

### DIFF
--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -593,6 +593,7 @@ func getOSDisk(name string, osDiskBlobURL string, isManaged bool, storageType st
 			Vhd: &compute.VirtualHardDisk{
 				URI: to.StringPtr(osDiskBlobURL),
 			},
+			DiskSizeGB: to.Int32Ptr(diskSize),
 		}
 	}
 	return osdisk


### PR DESCRIPTION
Problem:
Disk size is not configurable for VMs with non-managed disks. A user can pass a disk size parameter but it would not be used unless they are using managed disks. Now, all VMs can have their disk size
configured.

Solution:
Using disk size parameter regardless of whether disk is managed or not.

Issue:
https://github.com/rancher/rancher/issues/22074