### PR TITLE
Bump default azure image to 18.04

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -25,7 +25,7 @@ const (
 	defaultAzureLocation        = "westus"
 	defaultSSHUser              = "docker-user" // 'root' not allowed on Azure
 	defaultDockerPort           = 2376
-	defaultAzureImage           = "canonical:UbuntuServer:16.04.0-LTS:latest"
+	defaultAzureImage           = "canonical:UbuntuServer:18.04-LTS:latest"
 	defaultAzureVNet            = "docker-machine-vnet"
 	defaultAzureSubnet          = "docker-machine"
 	defaultAzureSubnetPrefix    = "192.168.0.0/16"


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/21207

Tested against `18.04-LTS` and it worked, `18.04.0-LTS` does not exist. 

<img width="620" alt="Screen Shot 2019-08-16 at 2 11 48 PM" src="https://user-images.githubusercontent.com/571419/63198498-d1f4fb80-c02f-11e9-9aea-d627d459cab0.png">

And in Azure: 

<img width="414" alt="Screen Shot 2019-08-16 at 2 01 45 PM" src="https://user-images.githubusercontent.com/571419/63198528-e2a57180-c02f-11e9-83e2-3c777be92a56.png">
