### PR TITLE
Disable vhd delete when using managed disks

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -419,8 +419,11 @@ func (d *Driver) Create() error {
 		d.ctx.PublicIPAddressID, d.ctx.SubnetID, d.ctx.NetworkSecurityGroupID, d.PrivateIPAddr); err != nil {
 		return err
 	}
-	if err := c.CreateStorageAccount(d.ctx, d.ResourceGroup, d.Location, storage.SkuName(d.StorageType)); err != nil {
-		return err
+	if !d.ManagedDisks {
+		// storage account is only necessary when using unmanaged disks
+		if err := c.CreateStorageAccount(d.ctx, d.ResourceGroup, d.Location, storage.SkuName(d.StorageType)); err != nil {
+			return err
+		}
 	}
 	if err := d.generateSSHKey(d.ctx); err != nil {
 		return err


### PR DESCRIPTION
Problem:
When deleting a VM that uses managed disks, all related resources besides the VM are left in Azure.

Solution:
Disable unnecessary delete logic that is executed when using managed disks. This logic leads to an error and cancels resource removal.
 
Issue:
https://github.com/rancher/rancher/issues/22100