### PR TITLE
Openstack multi network support

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -166,7 +166,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "OS_NETWORK_ID",
 			Name:   "openstack-net-id",
-			Usage:  "OpenStack comma seperated network id(s) the machine will be connected on",
+			Usage:  "OpenStack comma seperated network id(s) the machine will be connected on. (If floating ip pool is given, driver tries to find connected port in order of given networks to update floating ip)",
 			Value:  "",
 		},
 		mcnflag.StringFlag{
@@ -184,7 +184,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "OS_NETWORK_NAME",
 			Name:   "openstack-net-name",
-			Usage:  "OpenStack comma seperated network name(s) the machine will be connected on",
+			Usage:  "OpenStack comma seperated network name(s) the machine will be connected on. (If floating ip pool is given, driver tries to find connected port in order of given networks to update floating ip)",
 			Value:  "",
 		},
 		mcnflag.StringFlag{


### PR DESCRIPTION
## Summary

Openstack supports multiple **nova** network while creating new instance(server). This PR makes it possible through docker-machine driver for openstack.

### How to

Driver takes `network-name` or `network-id` as comma seperated lists. 
eg;
```
--openstack-network-id=id1,id2,id3
```
or 
```
--openstack-network-name=network1,network2
```

### Floating IP

When floating ip pool is given client go through the given networks one by one to find the first port and use this port when updating/creating floating ip.

Parameter list message is also alternated respectively. 

```
   --openstack-net-id        OpenStack comma seperated network id(s) the machine will be connected on. (If floating ip pool is given, driver tries to find connected port in order of given networks to update floating ip) [$OS_NETWORK_ID]
   --openstack-net-name        OpenStack comma seperated network name(s) the machine will be connected on. (If floating ip pool is given, driver tries to find connected port in order of given networks to update floating ip) [$OS_NETWORK_NAME]
 ```