### PR TITLE
Adding Tags and Custom Attributes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -315,7 +315,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:28b8c0c559f6b8bc9d6439384422e2ebc18791c1ac4346d27fc28442a3840c97"
+  digest = "1:3cdcd396a602ea7c645920069345f1fa69c128101fb696eb7d976e6b6667ff31"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -331,6 +331,7 @@
     "vapi/library",
     "vapi/library/finder",
     "vapi/rest",
+    "vapi/tags",
     "vapi/vcenter",
     "vim25",
     "vim25/debug",
@@ -490,6 +491,7 @@
     "github.com/vmware/govmomi/vapi/library",
     "github.com/vmware/govmomi/vapi/library/finder",
     "github.com/vmware/govmomi/vapi/rest",
+    "github.com/vmware/govmomi/vapi/tags",
     "github.com/vmware/govmomi/vapi/vcenter",
     "github.com/vmware/govmomi/vim25",
     "github.com/vmware/govmomi/vim25/mo",

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -162,6 +162,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "If using a non-B2D image the uploaded keys will need chown'ed, defaults to staff e.g. docker:staff",
 			Value:  defaultSSHUserGroup,
 		},
+		mcnflag.StringSliceFlag{
+			EnvVar: "",
+			Name:   "vmwarevsphere-tag",
+			Usage:  "vSphere tag id e.g. urn:xxx",
+		},
+		mcnflag.StringSliceFlag{
+			EnvVar: "",
+			Name:   "vmwarevsphere-custom-attribute",
+			Usage:  "vSphere custom attribute, format key/value e.g. '200=my custom value'",
+		},
 	}
 }
 
@@ -179,6 +189,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Username = flags.String("vmwarevsphere-username")
 	d.Password = flags.String("vmwarevsphere-password")
 	d.Networks = flags.StringSlice("vmwarevsphere-network")
+	d.Tags = flags.StringSlice("vmwarevsphere-tag")
+	d.CustomAttributes = flags.StringSlice("vmwarevsphere-custom-attribute")
 	d.Datastore = flags.String("vmwarevsphere-datastore")
 	d.Datacenter = flags.String("vmwarevsphere-datacenter")
 	// Sanitize input on ingress.

--- a/drivers/vmwarevsphere/utils.go
+++ b/drivers/vmwarevsphere/utils.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (d *Driver) exec(procman *guest.ProcessManager, arg string) (int64, error) {
+func (d *Driver) remoteExec(procman *guest.ProcessManager, arg string) (int64, error) {
 	var env []string
 	auth := NewAuthFlag(d.SSHUser, d.SSHPassword)
 	guestspec := types.GuestProgramSpec{
@@ -129,6 +129,14 @@ func (d *Driver) getSoapClient() (*govmomi.Client, error) {
 	}
 
 	return d.soap, nil
+}
+
+func (d *Driver) getRestLogin(c *vim25.Client) *rest.Client {
+	return rest.NewClient(c)
+}
+
+func (d *Driver) getUserInfo() *url.Userinfo {
+	return url.UserPassword(d.Username, d.Password)
 }
 
 func (d *Driver) restLogin(ctx context.Context, c *vim25.Client) (*library.Manager, error) {

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -52,6 +52,8 @@ type Driver struct {
 	Password               string
 	Network                string
 	Networks               []string
+	Tags                   []string
+	CustomAttributes       []string
 	Datastore              string
 	Datacenter             string
 	Folder                 string
@@ -328,7 +330,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := d.init(); err != nil {
+	if err := d.preCreate(); err != nil {
 		return err
 	}
 
@@ -469,7 +471,7 @@ func (d *Driver) Remove() error {
 		return nil
 	}
 
-	if err := d.init(); err != nil {
+	if err := d.preCreate(); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+// Category provides methods to create, read, update, delete, and enumerate categories.
+type Category struct {
+	ID              string   `json:"id,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	Cardinality     string   `json:"cardinality,omitempty"`
+	AssociableTypes []string `json:"associable_types,omitempty"`
+	UsedBy          []string `json:"used_by,omitempty"`
+}
+
+func (c *Category) hasType(kind string) bool {
+	for _, k := range c.AssociableTypes {
+		if kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Patch merges Category changes from the given src.
+// AssociableTypes can only be appended to and cannot shrink.
+func (c *Category) Patch(src *Category) {
+	if src.Name != "" {
+		c.Name = src.Name
+	}
+	if src.Description != "" {
+		c.Description = src.Description
+	}
+	if src.Cardinality != "" {
+		c.Cardinality = src.Cardinality
+	}
+	// Note that in order to append to AssociableTypes any existing types must be included in their original order.
+	for _, kind := range src.AssociableTypes {
+		if !c.hasType(kind) {
+			c.AssociableTypes = append(c.AssociableTypes, kind)
+		}
+	}
+}
+
+// CreateCategory creates a new category and returns the category ID.
+func (c *Manager) CreateCategory(ctx context.Context, category *Category) (string, error) {
+	// create avoids the annoyance of CreateTag requiring field keys to be included in the request,
+	// even though the field value can be empty.
+	type create struct {
+		Name            string   `json:"name"`
+		Description     string   `json:"description"`
+		Cardinality     string   `json:"cardinality"`
+		AssociableTypes []string `json:"associable_types"`
+	}
+	spec := struct {
+		Category create `json:"create_spec"`
+	}{
+		Category: create{
+			Name:            category.Name,
+			Description:     category.Description,
+			Cardinality:     category.Cardinality,
+			AssociableTypes: category.AssociableTypes,
+		},
+	}
+	if spec.Category.AssociableTypes == nil {
+		// otherwise create fails with invalid_argument
+		spec.Category.AssociableTypes = []string{}
+	}
+	url := internal.URL(c, internal.CategoryPath)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// UpdateCategory can update one or more of the AssociableTypes, Cardinality, Description and Name fields.
+func (c *Manager) UpdateCategory(ctx context.Context, category *Category) error {
+	spec := struct {
+		Category Category `json:"update_spec"`
+	}{
+		Category: Category{
+			AssociableTypes: category.AssociableTypes,
+			Cardinality:     category.Cardinality,
+			Description:     category.Description,
+			Name:            category.Name,
+		},
+	}
+	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
+}
+
+// DeleteCategory deletes an existing category.
+func (c *Manager) DeleteCategory(ctx context.Context, category *Category) error {
+	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// GetCategory fetches the category information for the given identifier.
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) GetCategory(ctx context.Context, id string) (*Category, error) {
+	if isName(id) {
+		cat, err := c.GetCategories(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range cat {
+			if cat[i].Name == id {
+				return &cat[i], nil
+			}
+		}
+	}
+	url := internal.URL(c, internal.CategoryPath).WithID(id)
+	var res Category
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// ListCategories returns all category IDs in the system.
+func (c *Manager) ListCategories(ctx context.Context) ([]string, error) {
+	url := internal.URL(c, internal.CategoryPath)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetCategories fetches an array of category information in the system.
+func (c *Manager) GetCategories(ctx context.Context) ([]Category, error) {
+	ids, err := c.ListCategories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list categories: %s", err)
+	}
+
+	var categories []Category
+	for _, id := range ids {
+		category, err := c.GetCategory(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get category %s: %s", id, err)
+		}
+
+		categories = append(categories, *category)
+
+	}
+	return categories, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+vUnless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+func (c *Manager) tagID(ctx context.Context, id string) (string, error) {
+	if isName(id) {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		return tag.ID, nil
+	}
+	return id, nil
+}
+
+// AttachTag attaches a tag ID to a managed object.
+func (c *Manager) AttachTag(ctx context.Context, tagID string, ref mo.Reference) error {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return err
+	}
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("attach")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
+// DetachTag detaches a tag ID from a managed object.
+// If the tag is already removed from the object, then this operation is a no-op and an error will not be thrown.
+func (c *Manager) DetachTag(ctx context.Context, tagID string, ref mo.Reference) error {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return err
+	}
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("detach")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
+// ListAttachedTags fetches the array of tag IDs attached to the given object.
+func (c *Manager) ListAttachedTags(ctx context.Context, ref mo.Reference) ([]string, error) {
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags")
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedTags fetches the array of tags attached to the given object.
+func (c *Manager) GetAttachedTags(ctx context.Context, ref mo.Reference) ([]Tag, error) {
+	ids, err := c.ListAttachedTags(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("get attached tags %s: %s", ref, err)
+	}
+
+	var info []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get tag %s: %s", id, err)
+		}
+		info = append(info, *tag)
+	}
+	return info, nil
+}
+
+// ListAttachedObjects fetches the array of attached objects for the given tag ID.
+func (c *Manager) ListAttachedObjects(ctx context.Context, tagID string) ([]mo.Reference, error) {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return nil, err
+	}
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("list-attached-objects")
+	var res []internal.AssociatedObject
+	if err := c.Do(ctx, url.Request(http.MethodPost, nil), &res); err != nil {
+		return nil, err
+	}
+
+	refs := make([]mo.Reference, len(res))
+	for i := range res {
+		refs[i] = res[i]
+	}
+	return refs, nil
+}
+
+// AttachedObjects is the response type used by ListAttachedObjectsOnTags.
+type AttachedObjects struct {
+	TagID     string         `json:"tag_id"`
+	Tag       *Tag           `json:"tag,omitempty"`
+	ObjectIDs []mo.Reference `json:"object_ids"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *AttachedObjects) UnmarshalJSON(b []byte) error {
+	var o struct {
+		TagID     string                      `json:"tag_id"`
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+
+	t.TagID = o.TagID
+	t.ObjectIDs = make([]mo.Reference, len(o.ObjectIDs))
+	for i := range o.ObjectIDs {
+		t.ObjectIDs[i] = o.ObjectIDs[i]
+	}
+
+	return nil
+}
+
+// ListAttachedObjectsOnTags fetches the array of attached objects for the given tag IDs.
+func (c *Manager) ListAttachedObjectsOnTags(ctx context.Context, tagID []string) ([]AttachedObjects, error) {
+	var ids []string
+	for i := range tagID {
+		id, err := c.tagID(ctx, tagID[i])
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+
+	spec := struct {
+		TagIDs []string `json:"tag_ids"`
+	}{ids}
+
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-objects-on-tags")
+	var res []AttachedObjects
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedObjectsOnTags combines ListAttachedObjectsOnTags and populates each Tag field.
+func (c *Manager) GetAttachedObjectsOnTags(ctx context.Context, tagID []string) ([]AttachedObjects, error) {
+	objs, err := c.ListAttachedObjectsOnTags(ctx, tagID)
+	if err != nil {
+		return nil, fmt.Errorf("list attached objects %s: %s", tagID, err)
+	}
+
+	tags := make(map[string]*Tag)
+
+	for i := range objs {
+		var err error
+		id := objs[i].TagID
+		tag, ok := tags[id]
+		if !ok {
+			tag, err = c.GetTag(ctx, id)
+			if err != nil {
+				return nil, fmt.Errorf("get tag %s: %s", id, err)
+			}
+			objs[i].Tag = tag
+		}
+	}
+
+	return objs, nil
+}
+
+// AttachedTags is the response type used by ListAttachedTagsOnObjects.
+type AttachedTags struct {
+	ObjectID mo.Reference `json:"object_id"`
+	TagIDs   []string     `json:"tag_ids"`
+	Tags     []Tag        `json:"tags,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *AttachedTags) UnmarshalJSON(b []byte) error {
+	var o struct {
+		ObjectID internal.AssociatedObject `json:"object_id"`
+		TagIDs   []string                  `json:"tag_ids"`
+	}
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+
+	t.ObjectID = o.ObjectID
+	t.TagIDs = o.TagIDs
+
+	return nil
+}
+
+// ListAttachedTagsOnObjects fetches the array of attached tag IDs for the given object IDs.
+func (c *Manager) ListAttachedTagsOnObjects(ctx context.Context, objectID []mo.Reference) ([]AttachedTags, error) {
+	var ids []internal.AssociatedObject
+	for i := range objectID {
+		ids = append(ids, internal.AssociatedObject(objectID[i].Reference()))
+	}
+
+	spec := struct {
+		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
+	}{ids}
+
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags-on-objects")
+	var res []AttachedTags
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedTagsOnObjects calls ListAttachedTagsOnObjects and populates each Tags field.
+func (c *Manager) GetAttachedTagsOnObjects(ctx context.Context, objectID []mo.Reference) ([]AttachedTags, error) {
+	objs, err := c.ListAttachedTagsOnObjects(ctx, objectID)
+	if err != nil {
+		return nil, fmt.Errorf("list attached tags %s: %s", objectID, err)
+	}
+
+	tags := make(map[string]*Tag)
+
+	for i := range objs {
+		for _, id := range objs[i].TagIDs {
+			var err error
+			tag, ok := tags[id]
+			if !ok {
+				tag, err = c.GetTag(ctx, id)
+				if err != nil {
+					return nil, fmt.Errorf("get tag %s: %s", id, err)
+				}
+				tags[id] = tag
+			}
+			objs[i].Tags = append(objs[i].Tags, *tag)
+		}
+	}
+
+	return objs, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
@@ -1,0 +1,226 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// Manager extends rest.Client, adding tag related methods.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+// isName returns true if the id is not a urn.
+func isName(id string) bool {
+	return !strings.HasPrefix(id, "urn:")
+}
+
+// Tag provides methods to create, read, update, delete, and enumerate tags.
+type Tag struct {
+	ID          string   `json:"id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	CategoryID  string   `json:"category_id,omitempty"`
+	UsedBy      []string `json:"used_by,omitempty"`
+}
+
+// Patch merges updates from the given src.
+func (t *Tag) Patch(src *Tag) {
+	if src.Name != "" {
+		t.Name = src.Name
+	}
+	if src.Description != "" {
+		t.Description = src.Description
+	}
+	if src.CategoryID != "" {
+		t.CategoryID = src.CategoryID
+	}
+}
+
+// CreateTag creates a new tag with the given Name, Description and CategoryID.
+func (c *Manager) CreateTag(ctx context.Context, tag *Tag) (string, error) {
+	// create avoids the annoyance of CreateTag requiring a "description" key to be included in the request,
+	// even though the field value can be empty.
+	type create struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		CategoryID  string `json:"category_id"`
+	}
+	spec := struct {
+		Tag create `json:"create_spec"`
+	}{
+		Tag: create{
+			Name:        tag.Name,
+			Description: tag.Description,
+			CategoryID:  tag.CategoryID,
+		},
+	}
+	if isName(tag.CategoryID) {
+		cat, err := c.GetCategory(ctx, tag.CategoryID)
+		if err != nil {
+			return "", err
+		}
+		spec.Tag.CategoryID = cat.ID
+	}
+	url := internal.URL(c, internal.TagPath)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// UpdateTag can update one or both of the tag Description and Name fields.
+func (c *Manager) UpdateTag(ctx context.Context, tag *Tag) error {
+	spec := struct {
+		Tag Tag `json:"update_spec"`
+	}{
+		Tag: Tag{
+			Name:        tag.Name,
+			Description: tag.Description,
+		},
+	}
+	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
+}
+
+// DeleteTag deletes an existing tag.
+func (c *Manager) DeleteTag(ctx context.Context, tag *Tag) error {
+	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// GetTag fetches the tag information for the given identifier.
+// The id parameter can be a Tag ID or Tag Name.
+func (c *Manager) GetTag(ctx context.Context, id string) (*Tag, error) {
+	if isName(id) {
+		tags, err := c.GetTags(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range tags {
+			if tags[i].Name == id {
+				return &tags[i], nil
+			}
+		}
+	}
+
+	url := internal.URL(c, internal.TagPath).WithID(id)
+	var res Tag
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+
+}
+
+// GetTagForCategory fetches the tag information for the given identifier in the given category.
+func (c *Manager) GetTagForCategory(ctx context.Context, id, category string) (*Tag, error) {
+	if category == "" {
+		return c.GetTag(ctx, id)
+	}
+
+	ids, err := c.ListTagsForCategory(ctx, category)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tagid := range ids {
+		tag, err := c.GetTag(ctx, tagid)
+		if err != nil {
+			return nil, fmt.Errorf("get tag for category %s %s: %s", category, tagid, err)
+		}
+		if tag.ID == id || tag.Name == id {
+			return tag, nil
+		}
+	}
+
+	return nil, fmt.Errorf("tag %q not found in category %q", id, category)
+}
+
+// ListTags returns all tag IDs in the system.
+func (c *Manager) ListTags(ctx context.Context) ([]string, error) {
+	url := internal.URL(c, internal.TagPath)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetTags fetches an array of tag information in the system.
+func (c *Manager) GetTags(ctx context.Context) ([]Tag, error) {
+	ids, err := c.ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get tags failed for: %s", err)
+	}
+
+	var tags []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get category %s failed for %s", id, err)
+		}
+
+		tags = append(tags, *tag)
+
+	}
+	return tags, nil
+}
+
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) ListTagsForCategory(ctx context.Context, id string) ([]string, error) {
+	if isName(id) {
+		cat, err := c.GetCategory(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		id = cat.ID
+	}
+
+	body := struct {
+		ID string `json:"category_id"`
+	}{id}
+	url := internal.URL(c, internal.TagPath).WithID(id).WithAction("list-tags-for-category")
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, body), &res)
+}
+
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) GetTagsForCategory(ctx context.Context, id string) ([]Tag, error) {
+	ids, err := c.ListTagsForCategory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get tag %s: %s", id, err)
+		}
+
+		tags = append(tags, *tag)
+	}
+	return tags, nil
+}


### PR DESCRIPTION
Adds two new flags to vmwarevsphere to allow passing of tags and custom attributes to be assigned to the newly created VM.

* Tags need to be  the full Tag ID, see `govc tags.info <tag>` to get the full urn.
* Custom Attributes need the Key name and a value in the format of "<int key>/<string value>". For instance if you do `govc fields.ls` to find the Key. Only accepts VirtualMachine type custom attributes.

        ```--vmwarevsphere-tag urn:vmomi:InventoryServiceTag:ee4de041-48d8-4709-b5a5-d08add628c75:GLOBAL \
        --vmwarevsphere-tag urn:vmomi:InventoryServiceTag:be5f9250-9b71-4a2d-b0f0-5de8a9edfca6:GLOBAL \
        --vmwarevsphere-tag urn:vmomi:InventoryServiceTag:d00f1cf2-6822-46a0-9602-679ea56efd57:GLOBAL \
        --vmwarevsphere-custom-attribute '203/Team xyz field value' \```