### PR TITLE
Remove copy public key

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -944,12 +944,12 @@ func (d *Driver) createKeyPair() error {
 		if err := mcnutils.CopyFile(d.SSHPrivateKeyPath, d.GetSSHKeyPath()); err != nil {
 			return err
 		}
-		if err := mcnutils.CopyFile(d.SSHPrivateKeyPath+".pub", d.GetSSHKeyPath()+".pub"); err != nil {
-			return err
-		}
 		if d.KeyName != "" {
 			log.Debugf("Using existing EC2 key pair: %s", d.KeyName)
 			return nil
+		}
+		if err := mcnutils.CopyFile(d.SSHPrivateKeyPath+".pub", d.GetSSHKeyPath()+".pub"); err != nil {
+			return err
 		}
 		keyPath = d.SSHPrivateKeyPath
 	}


### PR DESCRIPTION
Problem:
Machine breaks during provisioning if attempting to use an existing
key-pair and a public key is not present locally.

Solution:
Move logic for copy public key. Now, machine should only attempt
to copy the public key if key-pair does not exist.

Dependency for:
https://github.com/rmweir/rancher/pull/9