### PR TITLE
Typo prevents ContentLibrary installs in vsphere

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -339,7 +339,7 @@ func (d *Driver) Create() error {
 			return err
 		}
 		return d.createLegacy()
-	case "vm", "template", "libary":
+	case "vm", "template", "library":
 		if d.ContentLibrary != "" {
 			log.Infof("Creating VM from /%s/%s...", d.ContentLibrary, d.CloneFrom)
 			return d.createFromLibraryName()


### PR DESCRIPTION
s/libary/library/g
Allows detecting content library node templates appropriately

See rancher/rancher#24480