### PR TITLE
[vmwarevsphere] Add Disk Resizing to Cloning

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -328,6 +328,10 @@ func (d *Driver) createFromVmName() error {
 		return err
 	}
 
+	if err := d.resizeDisk(vm); err != nil {
+		return err
+	}
+
 	return d.postCreate(vm)
 }
 
@@ -411,5 +415,10 @@ func (d *Driver) createFromLibraryName() error {
 		return err
 	}
 
-	return d.postCreate(obj.(*object.VirtualMachine))
+	vm := obj.(*object.VirtualMachine)
+	if err := d.resizeDisk(vm); err != nil {
+		return err
+	}
+
+	return d.postCreate(vm)
 }


### PR DESCRIPTION
disk size parameters were being ignored during the cloning process. This adds a check after cloning a VM to resize the disk on the fly.