### PR TITLE
Adding Prefix Checks to Folder Find Logic

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -172,16 +172,9 @@ func (d *Driver) createLegacy() error {
 		spec.VAppConfig = &vApp
 	}
 
-	folders, err := d.datacenter.Folders(d.getCtx())
+	folder, err := d.findFolder()
 	if err != nil {
 		return err
-	}
-	folder := folders.VmFolder
-	if d.Folder != "" {
-		folder, err = d.finder.Folder(d.getCtx(), fmt.Sprintf("%s/%s", folders.VmFolder.InventoryPath, d.Folder))
-		if err != nil {
-			return err
-		}
 	}
 
 	ds, err := d.getDatastore(&spec)
@@ -300,16 +293,9 @@ func (d *Driver) createFromVmName() error {
 		return err
 	}
 
-	folders, err := d.datacenter.Folders(d.getCtx())
+	folder, err := d.findFolder()
 	if err != nil {
 		return err
-	}
-	folder := folders.VmFolder
-	if d.Folder != "" {
-		folder, err = d.finder.Folder(d.getCtx(), fmt.Sprintf("%s/%s", folders.VmFolder.InventoryPath, d.Folder))
-		if err != nil {
-			return err
-		}
 	}
 
 	task, err := vm2Clone.Clone(d.getCtx(), folder, d.MachineName, spec)

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/mcnflag"
@@ -207,7 +206,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.DatastoreCluster = flags.String("vmwarevsphere-datastore-cluster")
 	d.Datacenter = flags.String("vmwarevsphere-datacenter")
 	// Sanitize input on ingress.
-	d.Folder = strings.Trim(flags.String("vmwarevsphere-folder"), "/")
+	d.Folder = flags.String("vmwarevsphere-folder")
 	d.Pool = flags.String("vmwarevsphere-pool")
 	d.HostSystem = flags.String("vmwarevsphere-hostsystem")
 	d.CfgParams = flags.StringSlice("vmwarevsphere-cfgparam")

--- a/drivers/vmwarevsphere/utils.go
+++ b/drivers/vmwarevsphere/utils.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/vmware/govmomi"
@@ -264,4 +266,23 @@ func (d *Driver) restLogin(ctx context.Context, c *vim25.Client) (*library.Manag
 	}
 
 	return mgr, nil
+}
+
+func (d *Driver) findFolder() (*object.Folder, error) {
+	folders, err := d.datacenter.Folders(d.getCtx())
+	if err != nil {
+		return nil, err
+	}
+
+	if d.Folder != "" {
+		p := d.Folder
+		if !strings.HasPrefix(p, path.Join(d.Datacenter, "vm")) {
+			p = path.Join(folders.VmFolder.InventoryPath, strings.Trim(p, "/"))
+		}
+
+		return d.finder.Folder(d.getCtx(), p)
+	}
+
+	// root vm folder default
+	return folders.VmFolder, nil
 }


### PR DESCRIPTION
Fixing folders to work with deeper folder structures exposed a this old logic from the driver which prefixed folders when we are now passing in fully pathed folders. Leaving old system as a fall back for old nodetemplates.

https://github.com/rancher/rancher/issues/24840