### PR TITLE
Add support for Flatcar Container Linux

### DIFF
--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -25,13 +25,15 @@ EOF
 
 func init() {
 	Register("CoreOS", &RegisteredProvisioner{
-		New: NewCoreOSProvisioner,
+		New: func(d drivers.Driver) Provisioner {
+			return NewCoreOSProvisioner("coreos", d)
+		},
 	})
 }
 
-func NewCoreOSProvisioner(d drivers.Driver) Provisioner {
+func NewCoreOSProvisioner(osReleaseID string, d drivers.Driver) *CoreOSProvisioner {
 	return &CoreOSProvisioner{
-		NewSystemdProvisioner("coreos", d),
+		NewSystemdProvisioner(osReleaseID, d),
 	}
 }
 

--- a/libmachine/provision/flatcar.go
+++ b/libmachine/provision/flatcar.go
@@ -1,0 +1,25 @@
+package provision
+
+import (
+	"github.com/rancher/machine/libmachine/drivers"
+)
+
+func init() {
+	Register("Flatcar", &RegisteredProvisioner{
+		New: NewFlatcarProvisioner,
+	})
+}
+
+func NewFlatcarProvisioner(d drivers.Driver) Provisioner {
+	return &FlatcarProvisioner{
+		NewCoreOSProvisioner("flatcar", d),
+	}
+}
+
+type FlatcarProvisioner struct {
+	*CoreOSProvisioner
+}
+
+func (provisioner *FlatcarProvisioner) String() string {
+	return "flatcar"
+}


### PR DESCRIPTION
CoreOS Container Linux will go end of life on May 26th. Flatcar Linux is one of the possible alternatives.

This PR adds support for Flatcar Container Linux to be used for provisioning Kubernetes clusters with Rancher.

It reuses the existing CoreOS provisioner.