### PR TITLE
Change default storage driver for redhat

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -134,7 +134,7 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for redhat
-	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi!
This PR changes outdated `devicemapper` to `overlay2` as a default storage driver for redhat based operating systems.

Issue from main repository:
https://github.com/rancher/rancher/issues/18065