### PR TITLE
change default storage driver for redhat

### DIFF
--- a/contrib/completion/zsh/_docker-machine
+++ b/contrib/completion/zsh/_docker-machine
@@ -175,7 +175,7 @@ __docker-machine_subcommand() {
         "*:host:__docker-machine_hosts_all"
     )
     opts_driver=('amazonec2' 'azure' 'digitalocean' 'exoscale' 'generic' 'google' 'hyperv' 'none' 'openstack' 'rackspace' 'softlayer' 'virtualbox' 'vmwarefusion' 'vmwarevcloudair' 'vmwarevsphere')
-    opts_storage_driver=('overlay' 'aufs' 'btrfs' 'devicemapper' 'vfs' 'zfs')
+    opts_storage_driver=('overlay' 'overlay2' 'aufs' 'btrfs' 'devicemapper' 'vfs' 'zfs')
     integer ret=1
 
     case "$words[1]" in

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -134,7 +134,7 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for redhat
-	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -14,7 +14,7 @@ func TestRedHatDefaultStorageDriver(t *testing.T) {
 	p := NewRedHatProvisioner("", &fakedriver.Driver{})
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "devicemapper" {
-		t.Fatal("Default storage driver should be devicemapper")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }


### PR DESCRIPTION
Upgrades redhat to overlay2 per this docker/machine PR: https://github.com/docker/machine/pull/4560/files

https://github.com/rancher/rancher/issues/18065
