### PR TITLE
Remove register Microsoft.Subscription from Azure

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -363,7 +363,6 @@ func (d *Driver) PreCreateCheck() (err error) {
 		"Microsoft.Compute",
 		"Microsoft.Network",
 		"Microsoft.Storage",
-		"Microsoft.Subscription",
 		"Microsoft.Resources"); err != nil {
 		return err
 	}

--- a/drivers/azure/azureutil/clients.go
+++ b/drivers/azure/azureutil/clients.go
@@ -170,16 +170,6 @@ func (a AzureClient) galleryImageVersionsClient() compute.GalleryImageVersionsCl
 	return c
 }
 
-func (a AzureClient) resourceSkusClient() compute.ResourceSkusClient {
-	c := compute.NewResourceSkusClientWithBaseURI(a.env.ResourceManagerEndpoint, a.subscriptionID)
-	c.Authorizer = a.auth
-	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
-	c.RequestInspector = withInspection()
-	c.ResponseInspector = byInspecting()
-	c.PollingDelay = defaultClientPollingDelay
-	return c
-}
-
 func (a AzureClient) disksClient() compute.DisksClient {
 	c := compute.NewDisksClientWithBaseURI(a.env.ResourceManagerEndpoint, a.subscriptionID)
 	c.Authorizer = a.auth


### PR DESCRIPTION
This PR rolls back a change that was added in as part of https://github.com/rancher/machine/commit/b13f35b91cacbc867e7a0fb584ae65dffc3bb1aa#diff-93a074128ed8940ea0dafbd000270978R349.

`RegisterResourceProviders` makes a call to Azure to ensure that the current Azure subscription has the ability to deploy a resource for a given [resource provider](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types). Rancher does not require the ability to deploy a new subscription, so registering the Microsoft.Subscriptions resource provider is unnecessary. However, creating a resource group (Microsoft.Resources), a storage account (Microsoft.Storage), a network security group (Microsoft.Network), and a Virtual Machine (Microsoft.Compute) should still be required.

Also makes a nit commit to remove an unused client defined in `clients.go` as part of the Uplift Azure commit.

Related Issue: https://github.com/rancher/rancher/issues/27447