### PR TITLE
Fix cloud-init hostname configuration for vSphere integration

### DIFF
--- a/drivers/vmwarevsphere/cloudinit.go
+++ b/drivers/vmwarevsphere/cloudinit.go
@@ -154,7 +154,7 @@ func (d *Driver) createCloudInitIso() error {
 		return err
 	}
 
-	md := []byte(fmt.Sprintf("#local-hostname: %s\n", d.MachineName))
+	md := []byte(fmt.Sprintf("local-hostname: %s\n", d.MachineName))
 	if err = ioutil.WriteFile(metadata, md, perm); err != nil {
 		return err
 	}


### PR DESCRIPTION
The cloud-init `meta-data` file is in YAML format. The leading asterisk commented out the `local-hostname` option so that the hostname was never applied to the machine by cloud-init.

See https://github.com/rancher/rancher/issues/27846