### PR TITLE
[vSphere] Don't override GuestId for VMs created from a template

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -218,7 +218,6 @@ func (d *Driver) createFromVmName() error {
 	spec := types.VirtualMachineCloneSpec{
 		Location: loc,
 		Config: &types.VirtualMachineConfigSpec{
-			GuestId:    "otherLinux64Guest",
 			NumCPUs:    int32(d.CPU),
 			MemoryMB:   int64(d.Memory),
 			VAppConfig: d.getVAppConfig(),


### PR DESCRIPTION
The driver should inherit the GuestId (OS type) from the parent VM or template.  This avoids unexpected warnings when, for example, the VMware Paravirtual SCSI controller is selected.