### PR TITLE
use "]" instead of " " to split the VM folder name from the datastore

### DIFF
--- a/drivers/vmwarevsphere/vm.go
+++ b/drivers/vmwarevsphere/vm.go
@@ -29,7 +29,7 @@ func (d *Driver) getVmFolder(vm *object.VirtualMachine) (string, error) {
 
 	p := mvm.Summary.Config.VmPathName
 	sp := strings.Split(p, "]")
-	path := strings.Replace(sp[1], fmt.Sprintf("/%s.vmx", d.MachineName), "", 1)
+	path := strings.TrimSpace(strings.Replace(sp[1], fmt.Sprintf("/%s.vmx", d.MachineName), "", 1))
 
 	return path, nil
 }

--- a/drivers/vmwarevsphere/vm.go
+++ b/drivers/vmwarevsphere/vm.go
@@ -28,7 +28,7 @@ func (d *Driver) getVmFolder(vm *object.VirtualMachine) (string, error) {
 	}
 
 	p := mvm.Summary.Config.VmPathName
-	sp := strings.Split(p, " ")
+	sp := strings.Split(p, "]")
 	path := strings.Replace(sp[1], fmt.Sprintf("/%s.vmx", d.MachineName), "", 1)
 
 	return path, nil


### PR DESCRIPTION
Datastores can contain spaces which can cause issues such as https://github.com/rancher/rancher/issues/27699