### PR TITLE
AWS driver: Detect root device name from AMI

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -529,3 +529,31 @@ func TestBase64UserDataIsCorrectWhenFileProvided(t *testing.T) {
 	assert.NoError(t, ud_err)
 	assert.Equal(t, contentBase64, userdata)
 }
+
+func TestDefaultAMI(t *testing.T) {
+	driver := NewCustomTestDriver(&fakeEC2WithLogin{})
+
+	err := driver.checkAMI()
+
+	assert.Equal(t, "/dev/sda1", driver.DeviceName)
+	assert.NoError(t, err)
+}
+
+func TestRootDeviceName(t *testing.T) {
+	driver := NewCustomTestDriver(&fakeEC2WithLogin{})
+	driver.AMI = "ami-0eeb1ef502d7b850d" // Fedora CoreOS image
+
+	err := driver.checkAMI()
+
+	assert.Equal(t, "/dev/xvda", driver.DeviceName)
+	assert.NoError(t, err)
+}
+
+func TestInvalidAMI(t *testing.T) {
+	driver := NewCustomTestDriver(&fakeEC2WithLogin{})
+	driver.AMI = "ami-000" // Invalid AMI
+
+	err := driver.checkAMI()
+
+	assert.Error(t, err)
+}

--- a/drivers/amazonec2/ec2client.go
+++ b/drivers/amazonec2/ec2client.go
@@ -53,4 +53,8 @@ type Ec2Client interface {
 
 	WaitUntilSpotInstanceRequestFulfilled(input *ec2.DescribeSpotInstanceRequestsInput) error
 	CancelSpotInstanceRequests(input *ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error)
+
+	// Images
+
+	DescribeImages(input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
 }

--- a/drivers/amazonec2/stub_test.go
+++ b/drivers/amazonec2/stub_test.go
@@ -3,6 +3,7 @@ package amazonec2
 import (
 	"errors"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
@@ -95,6 +96,25 @@ func (f *fakeEC2WithLogin) DescribeAccountAttributes(input *ec2.DescribeAccountA
 			},
 		},
 	}, nil
+}
+
+func (f *fakeEC2WithLogin) DescribeImages(input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	if len(input.ImageIds) == 0 || input.ImageIds[0] == nil {
+		return nil, errors.New("bad input")
+	}
+	amiID := *input.ImageIds[0]
+	switch amiID {
+	case defaultAmiId, "ami-0c43b23f011ba5061": // two Ubuntu images
+		return &ec2.DescribeImagesOutput{Images: []*ec2.Image{
+			&ec2.Image{RootDeviceName: aws.String("/dev/sda1")},
+		}}, nil
+	case "ami-0eeb1ef502d7b850d": // Fedora CoreOS image
+		return &ec2.DescribeImagesOutput{Images: []*ec2.Image{
+			&ec2.Image{RootDeviceName: aws.String("/dev/xvda")},
+		}}, nil
+	default:
+		return nil, errors.New("no mock for input")
+	}
 }
 
 type fakeEC2SecurityGroupTestRecorder struct {


### PR DESCRIPTION
Currently, in order to deploy an AWS EC2 instance where root device name is not /dev/sda1 (e.g. official Fedora CoreOS AMIs use /dev/xvda), you have to specify the flag --amazonec2-device-name=/dev/xvda.

However:
1. Rancher UI does not allow setting easily this value in AWS EC2 node templates;
2. As [documented by AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html),    the root device name is specified in the AMI, so the best is to get the information automatically from the AMI.

Therefore, this commit removes the default option for --amazonec2-device-name, and if a value is not specified, it uses the root device name specified in the AMI.
