### PR TITLE
[WIP] Accept registry options for create command

### DIFF
--- a/cmd/rancher-machine/machine.go
+++ b/cmd/rancher-machine/machine.go
@@ -3,9 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
-
 	"path/filepath"
+	"strconv"
 
 	"github.com/rancher/machine/commands"
 	"github.com/rancher/machine/commands/mcndirs"

--- a/commands/create.go
+++ b/commands/create.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/commands/mcndirs"
 	"github.com/rancher/machine/libmachine"
 	"github.com/rancher/machine/libmachine/auth"
@@ -128,6 +130,18 @@ var (
 			Usage: "Support extra SANs for TLS certs",
 			Value: &cli.StringSlice{},
 		},
+		cli.StringFlag{
+			Name:  "registry-username",
+			Usage: "Username for private registry authentication",
+		},
+		cli.StringFlag{
+			Name:  "registry-password",
+			Usage: "Password for private registry authentication",
+		},
+		cli.StringFlag{
+			Name:  "registry-url",
+			Usage: "Private registry url",
+		},
 	}
 )
 
@@ -200,6 +214,11 @@ func cmdCreateInner(c CommandLine, api libmachine.API) error {
 			ArbitraryFlags:     c.StringSlice("swarm-opt"),
 			ArbitraryJoinFlags: c.StringSlice("swarm-join-opt"),
 			IsExperimental:     c.Bool("swarm-experimental"),
+		},
+		RegistryOptions: &registry.Options{
+			Username: c.String("registry-username"),
+			Password: c.String("registry-password"),
+			URL:      c.String("registry-url"),
 		},
 	}
 

--- a/commands/create.go
+++ b/commands/create.go
@@ -131,16 +131,19 @@ var (
 			Value: &cli.StringSlice{},
 		},
 		cli.StringFlag{
-			Name:  "registry-username",
-			Usage: "Username for private registry authentication",
+			EnvVar: "MACHINE_REGISTRY_USERNAME",
+			Name:   "registry-username",
+			Usage:  "Username for private registry authentication",
 		},
 		cli.StringFlag{
-			Name:  "registry-password",
-			Usage: "Password for private registry authentication",
+			EnvVar: "MACHINE_REGISTRY_PASSWORD",
+			Name:   "registry-password",
+			Usage:  "Password for private registry authentication",
 		},
 		cli.StringFlag{
-			Name:  "registry-url",
-			Usage: "Private registry url",
+			EnvVar: "MACHINE_REGISTRY_URL",
+			Name:   "registry-url",
+			Usage:  "Private registry url",
 		},
 	}
 )

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -3,6 +3,8 @@ package host
 import (
 	"regexp"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/cert"
 	"github.com/rancher/machine/libmachine/drivers"
@@ -47,12 +49,13 @@ type Host struct {
 }
 
 type Options struct {
-	Driver        string
-	Memory        int
-	Disk          int
-	EngineOptions *engine.Options
-	SwarmOptions  *swarm.Options
-	AuthOptions   *auth.Options
+	Driver          string
+	Memory          int
+	Disk            int
+	EngineOptions   *engine.Options
+	SwarmOptions    *swarm.Options
+	AuthOptions     *auth.Options
+	RegistryOptions *registry.Options
 }
 
 type Metadata struct {
@@ -265,7 +268,7 @@ func (h *Host) ConfigureAuth() error {
 	// and modularity of the provisioners should be).
 	//
 	// Call provision to re-provision the certs properly.
-	return provisioner.Provision(swarm.Options{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
+	return provisioner.Provision(swarm.Options{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions, *h.HostOptions.RegistryOptions)
 }
 
 func (h *Host) ConfigureAllAuth() error {
@@ -282,5 +285,5 @@ func (h *Host) Provision() error {
 		return err
 	}
 
-	return provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
+	return provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions, *h.HostOptions.RegistryOptions)
 }

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"path/filepath"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/drivers/errdriver"
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/cert"
@@ -83,6 +85,7 @@ func (api *Client) NewHost(driverName string, rawDriver []byte) (*host.Host, err
 				Image:    "swarm:latest",
 				Strategy: "spread",
 			},
+			RegistryOptions: &registry.Options{},
 		},
 	}, nil
 }
@@ -168,7 +171,12 @@ func (api *Client) performCreate(h *host.Host) error {
 	}
 
 	log.Infof("Provisioning with %s...", provisioner.String())
-	if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
+	if err := provisioner.Provision(
+		*h.HostOptions.SwarmOptions,
+		*h.HostOptions.AuthOptions,
+		*h.HostOptions.EngineOptions,
+		*h.HostOptions.RegistryOptions,
+	); err != nil {
 		return fmt.Errorf("Error running provisioning: %s", err)
 	}
 

--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -3,6 +3,8 @@ package provision
 import (
 	"fmt"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -88,10 +90,11 @@ func (provisioner *ArchProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)

--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -143,6 +143,11 @@ func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOp
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	log.Debug("Configuring swarm")
 	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
 		return err

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -9,6 +9,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/commands/mcndirs"
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
@@ -34,11 +36,12 @@ func NewBoot2DockerProvisioner(d drivers.Driver) Provisioner {
 }
 
 type Boot2DockerProvisioner struct {
-	OsReleaseInfo *OsRelease
-	Driver        drivers.Driver
-	AuthOptions   auth.Options
-	EngineOptions engine.Options
-	SwarmOptions  swarm.Options
+	OsReleaseInfo   *OsRelease
+	Driver          drivers.Driver
+	AuthOptions     auth.Options
+	EngineOptions   engine.Options
+	SwarmOptions    swarm.Options
+	RegistryOptions registry.Options
 }
 
 func (provisioner *Boot2DockerProvisioner) String() string {
@@ -215,7 +218,7 @@ You also might want to clear any VirtualBox host only interfaces you are not usi
 	}
 }
 
-func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	var (
 		err error
 	)
@@ -229,6 +232,7 @@ func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options,
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	if provisioner.EngineOptions.StorageDriver == "" {

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -259,6 +259,11 @@ func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options,
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	err = configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err
 }

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -132,7 +132,15 @@ func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	log.Debug("Configuring swarm")
-	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
-	return err
+	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/machine/libmachine/engine"
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/rancher/machine/libmachine/provision/pkgaction"
+	"github.com/rancher/machine/libmachine/registry"
 	"github.com/rancher/machine/libmachine/swarm"
 	"github.com/rancher/machine/libmachine/versioncmp"
 )
@@ -109,10 +110,11 @@ func (provisioner *CoreOSProvisioner) Package(name string, action pkgaction.Pack
 	return nil
 }
 
-func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -123,15 +123,15 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
-	log.Debug("Logging into private registry")
-	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
-		return err
-	}
-
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
 
 	log.Debug("configuring auth")
 	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/fake_provisioner.go
+++ b/libmachine/provision/fake_provisioner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/machine/libmachine/engine"
 	"github.com/rancher/machine/libmachine/provision/pkgaction"
 	"github.com/rancher/machine/libmachine/provision/serviceaction"
+	"github.com/rancher/machine/libmachine/registry"
 	"github.com/rancher/machine/libmachine/swarm"
 )
 
@@ -63,7 +64,7 @@ func (fp *FakeProvisioner) CompatibleWithHost() bool {
 	return true
 }
 
-func (fp *FakeProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (fp *FakeProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	return nil
 }
 

--- a/libmachine/provision/fedora_coreos.go
+++ b/libmachine/provision/fedora_coreos.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -110,10 +112,11 @@ func (provisioner *FedoraCoreOSProvisioner) Package(name string, action pkgactio
 }
 
 // Provision provisions the machine
-func (provisioner *FedoraCoreOSProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *FedoraCoreOSProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
@@ -135,4 +138,3 @@ func (provisioner *FedoraCoreOSProvisioner) Provision(swarmOptions swarm.Options
 	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err
 }
-

--- a/libmachine/provision/fedora_coreos.go
+++ b/libmachine/provision/fedora_coreos.go
@@ -134,6 +134,11 @@ func (provisioner *FedoraCoreOSProvisioner) Provision(swarmOptions swarm.Options
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	log.Debug("Configuring swarm")
 	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -22,6 +24,7 @@ type GenericProvisioner struct {
 	AuthOptions       auth.Options
 	EngineOptions     engine.Options
 	SwarmOptions      swarm.Options
+	RegistryOptions   registry.Options
 }
 
 type GenericSSHCommander struct {

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -3,6 +3,8 @@ package provision
 import (
 	"fmt"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -69,10 +71,11 @@ type Provisioner interface {
 	// Do the actual provisioning piece:
 	//     1. Set the hostname on the instance.
 	//     2. Install Docker if it is not present.
-	//     3. Configure the daemon to accept connections over TLS.
-	//     4. Copy the needed certificates to the server and local config dir.
-	//     5. Configure / activate swarm if applicable.
-	Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error
+	// 	   3. Authenticate to private registry if there is one
+	//     4. Configure the daemon to accept connections over TLS.
+	//     5. Copy the needed certificates to the server and local config dir.
+	//     6. Configure / activate swarm if applicable.
+	Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error
 
 	// Perform action on a named service e.g. stop
 	Service(name string, action serviceaction.ServiceAction) error

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -138,6 +138,11 @@ func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, aut
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	log.Debugf("Configuring swarm")
 	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/commands/mcndirs"
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
@@ -92,12 +94,13 @@ func (provisioner *RancherProvisioner) Package(name string, action pkgaction.Pac
 	return nil
 }
 
-func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	log.Debugf("Running RancherOS provisioner on %s", provisioner.Driver.GetMachineName())
 
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	if provisioner.EngineOptions.StorageDriver == "" {

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"text/template"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -127,10 +129,11 @@ func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for redhat

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -178,6 +178,11 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
+		return err
+	}
+
 	err = configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err
 }

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -168,15 +168,15 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 		return err
 	}
 
-	log.Debug("Logging into private registry")
-	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
-		return err
-	}
-
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
 
 	log.Debug("Configuring auth")
 	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -104,10 +106,11 @@ func (provisioner *SUSEProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	// figure out the filesystem used by /var/lib/docker
@@ -162,6 +165,11 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 
 	log.Debug("Waiting for docker daemon")
 	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -133,15 +133,15 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 		return err
 	}
 
-	log.Debug("Logging into private registry")
-	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
-		return err
-	}
-
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
 
 	log.Debug("configuring auth")
 	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -140,7 +140,7 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 		return err
 	}
 
-	log.Debug("Logging into private registry")
+	log.Info("Logging into private registry")
 	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -150,14 +150,14 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
-	log.Debug("Logging into private registry")
-	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
-		return err
-	}
-
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
 
 	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/engine"
@@ -112,10 +114,11 @@ func (provisioner *UbuntuProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+	provisioner.RegistryOptions = registryOptions
 	swarmOptions.Env = engineOptions.Env
 
 	storageDriver, err := decideStorageDriver(provisioner, DefaultStorageDriver, engineOptions.StorageDriver)
@@ -144,6 +147,11 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 	}
 
 	if err := makeDockerOptionsDir(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("Logging into private registry")
+	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -156,7 +156,7 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
-	log.Debug("Logging into private registry")
+	log.Info("Logging into private registry")
 	if err := dockerLoginGeneric(provisioner, registryOptions); err != nil {
 		return err
 	}

--- a/libmachine/provision/utils_test.go
+++ b/libmachine/provision/utils_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rancher/machine/libmachine/registry"
+
 	"github.com/rancher/machine/drivers/fakedriver"
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/engine"
@@ -202,7 +204,7 @@ func (provisioner *fakeProvisioner) Package(name string, action pkgaction.Packag
 	return nil
 }
 
-func (provisioner *fakeProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *fakeProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options, registryOptions registry.Options) error {
 	return nil
 }
 

--- a/libmachine/registry/registry.go
+++ b/libmachine/registry/registry.go
@@ -1,0 +1,7 @@
+package registry
+
+type Options struct {
+	Username string
+	Password string
+	URL      string
+}


### PR DESCRIPTION
Issue:
- rancher/rancher#26366

This adds the ability to authenticate to a private registry during the machine provisioning process, which enables docker run commands that use images from that private registry.

Example:
```bash
MACHINE_REGISTRY_USERNAME=user MACHINE_REGISTRY_PASSWORD=xxxxx 
MACHINE_REGISTRY_URL=registry.example.com rancher-machine --debug create -d digitalocean --engine-install-url 
https://releases.rancher.com/install-docker/19.03.sh --digitalocean-size s-2vcpu-2gb --digitalocean-ssh-port 22
--digitalocean-access-token xxxxx --digitalocean-image ubuntu-18-04-x64 --digitalocean-ssh-user root 
--digitalocean-region sfo2 node-test
```