### PR TITLE
Added support for provisioning amazon linux 2 based instances

### DIFF
--- a/libmachine/provision/amazonlinux.go
+++ b/libmachine/provision/amazonlinux.go
@@ -1,0 +1,157 @@
+package provision
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/rancher/machine/libmachine/auth"
+	"github.com/rancher/machine/libmachine/drivers"
+	"github.com/rancher/machine/libmachine/engine"
+	"github.com/rancher/machine/libmachine/log"
+	"github.com/rancher/machine/libmachine/mcnutils"
+	"github.com/rancher/machine/libmachine/provision/pkgaction"
+	"github.com/rancher/machine/libmachine/provision/serviceaction"
+	"github.com/rancher/machine/libmachine/swarm"
+)
+
+func init() {
+	Register("amzn", &RegisteredProvisioner{
+		New: NewAmazonLinuxProvisioner,
+	})
+}
+
+func NewAmazonLinuxProvisioner(d drivers.Driver) Provisioner {
+	return &AmazonLinuxProvisioner{
+		NewSystemdProvisioner("amzn", d),
+	}
+}
+
+type AmazonLinuxProvisioner struct {
+	SystemdProvisioner
+}
+
+func (provisioner *AmazonLinuxProvisioner) String() string {
+	return "amzn"
+}
+
+func (provisioner *AmazonLinuxProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	var packageAction string
+
+	switch action {
+	case pkgaction.Install:
+		packageAction = "install"
+	case pkgaction.Remove:
+		packageAction = "remove"
+	case pkgaction.Purge:
+		packageAction = "remove"
+	case pkgaction.Upgrade:
+		packageAction = "upgrade"
+	}
+
+	command := fmt.Sprintf("sudo -E yum %s -y %s", packageAction, name)
+
+	if _, err := provisioner.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *AmazonLinuxProvisioner) dockerDaemonResponding() bool {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
+		return false
+	}
+
+	// The daemon is up if the command worked.  Carry on.
+	return true
+}
+
+func (provisioner *AmazonLinuxProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	provisioner.SwarmOptions = swarmOptions
+	provisioner.AuthOptions = authOptions
+	provisioner.EngineOptions = engineOptions
+	swarmOptions.Env = engineOptions.Env
+
+	// set default storage driver for redhat
+	storageDriver, err := decideStorageDriver(provisioner, DefaultStorageDriver, engineOptions.StorageDriver)
+	if err != nil {
+		return err
+	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
+
+	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		return err
+	}
+
+	for _, pkg := range provisioner.Packages {
+		log.Debugf("installing base package: name=%s", pkg)
+		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
+			return err
+		}
+	}
+
+	log.Debug("Installing docker")
+	if err := provisioner.Package("docker", pkgaction.Install); err != nil {
+		return err
+	}
+
+	log.Debug("Starting systemd docker service")
+	if err := provisioner.Service("docker", serviceaction.Start); err != nil {
+		return err
+	}
+
+	log.Debug("Waiting for docker daemon")
+	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {
+		return err
+	}
+
+	if err := makeDockerOptionsDir(provisioner); err != nil {
+		return err
+	}
+
+	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
+
+	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	err = configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
+	return err
+}
+
+func (provisioner *AmazonLinuxProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
+	var (
+		engineCfg  bytes.Buffer
+		configPath = provisioner.DaemonOptionsFile
+	)
+
+	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
+	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
+
+	// systemd / redhat will not load options if they are on newlines
+	// instead, it just continues with a different set of options; yeah...
+	t, err := template.New("engineConfig").Parse(engineConfigTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	engineConfigContext := EngineConfigContext{
+		DockerPort:       dockerPort,
+		AuthOptions:      provisioner.AuthOptions,
+		EngineOptions:    provisioner.EngineOptions,
+		DockerOptionsDir: provisioner.DockerOptionsDir,
+	}
+
+	t.Execute(&engineCfg, engineConfigContext)
+
+	daemonOptsDir := configPath
+	return &DockerOptions{
+		EngineOptions:     engineCfg.String(),
+		EngineOptionsPath: daemonOptsDir,
+	}, nil
+}


### PR DESCRIPTION
The PR adds support for amazonlinux 2 provisioner which is based off the default SystemdProvisioner.

This should allow rancher-machine and Rancher to now launch RKE clusters using amazonlinux 2 ami's.