### PR TITLE
Add Amazon Linux provisioner

### DIFF
--- a/libmachine/provision/amazon.go
+++ b/libmachine/provision/amazon.go
@@ -1,0 +1,25 @@
+package provision
+
+import (
+	"github.com/rancher/machine/libmachine/drivers"
+)
+
+func init() {
+	Register("Amazon", &RegisteredProvisioner{
+		New: NewAmazonProvisioner,
+	})
+}
+
+func NewAmazonProvisioner(d drivers.Driver) Provisioner {
+	return &AmazonProvisioner{
+		NewRedHatProvisioner("amzn", d),
+	}
+}
+
+type AmazonProvisioner struct {
+	*RedHatProvisioner
+}
+
+func (provisioner *AmazonProvisioner) String() string {
+	return "amazon"
+}


### PR DESCRIPTION
This follows the same strategy as the Centos provisioner, which just wraps the RedHat provisioner.

Caveat: The proper way to install docker on Amazon is [via amazon-linux-extras](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html). This patch relies on the fact that the RedHat provisioner calls installDockerGeneric, which skips the docker install if it's already present, meaning this patch only "supports" Amazon Linux if the selected AMI already has Docker installed.