### PR TITLE
Attempt ssh

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -181,32 +181,37 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	configuredMacIPs, err := vm.WaitForNetIP(d.getCtx(), true)
-	if err != nil {
-		return "", err
-	}
+	for i := 0; i < 5; i++ {
+		configuredMacIPs, err := vm.WaitForNetIP(d.getCtx(), true)
+		if err != nil {
+			return "", err
+		}
 
-	log.Debugf("[GetIP] configuredMacIPs: %+v", configuredMacIPs)
+		log.Debugf("[GetIP] configuredMacIPs: %+v", configuredMacIPs)
 
-	for _, ips := range configuredMacIPs {
-		for _, ip := range ips {
-			// Try to filter out link local addresses and the default address of
-			// the Docker0 bridge
-			netIP := net.ParseIP(ip)
-			if netIP.To4() != nil && netIP.IsGlobalUnicast() && !netIP.Equal(net.ParseIP(dockerBridgeIP)) {
-				// The IP has to be set on the driver in order to test the IP using SSH
-				log.Debugf("[GetIP] Attempting SSH to IP %v", ip)
-				d.IPAddress = ip
-				_, err := drivers.RunSSHCommandFromDriver(d, "exit 0")
-				if err != nil {
-					// IP failed the SSH test so drop it so it's not saved on the driver if they all fail
-					d.IPAddress = ""
-					continue
+		for _, ips := range configuredMacIPs {
+			for _, ip := range ips {
+				// Try to filter out link local addresses and the default address of
+				// the Docker0 bridge
+				netIP := net.ParseIP(ip)
+				if netIP.To4() != nil && netIP.IsGlobalUnicast() && !netIP.Equal(net.ParseIP(dockerBridgeIP)) {
+					// The IP has to be set on the driver in order to test the IP using SSH
+					log.Debugf("[GetIP] Attempting SSH to IP %v", ip)
+					d.IPAddress = ip
+					_, err := drivers.RunSSHCommandFromDriver(d, "exit 0")
+					if err != nil {
+						// IP failed the SSH test so drop it so it's not saved on the driver if they all fail
+						d.IPAddress = ""
+						continue
+					}
+					return d.IPAddress, nil
 				}
-				return d.IPAddress, nil
 			}
 		}
+		log.Debug("[GetIP] could not connect to any IP, sleeping for 10 seconds then trying again")
+		time.Sleep(10 * time.Second)
 	}
+
 	return "", errors.New("No valid IP despite waiting for one - check DHCP status")
 }
 

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -39,7 +39,7 @@ func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
 		return "", err
 	}
 
-	log.Debugf("About to run SSH command:\n%s", command)
+	log.Debugf("About to run SSH command: %s", command)
 
 	output, err := client.Output(command)
 	log.Debugf("SSH cmd err, output: %v: %s", err, output)


### PR DESCRIPTION
Problem: 
vsphere can have multiple IP addresses on the hose, some of those which are not reachable from the outside. In those cases if that IP ends up first in the list machine won't be able to connect. 

Solution:
Loop over the list of IP addresses and attempt to ssh into the node to ensure a connection can be made. 