### PR TITLE
Add no-op provisioner for create command

### DIFF
--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -167,6 +167,11 @@ func (api *Client) performCreate(h *host.Host) error {
 		return fmt.Errorf("Error detecting OS: %s", err)
 	}
 
+	if provisioner.String() == "no-op" {
+		log.Info("no-op provisioner does nothing, provisioning skipping")
+		return nil
+	}
+
 	log.Infof("Provisioning with %s...", provisioner.String())
 	if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
 		return fmt.Errorf("Error running provisioning: %s", err)

--- a/libmachine/provision/no_docker.go
+++ b/libmachine/provision/no_docker.go
@@ -1,0 +1,59 @@
+package provision
+
+import (
+	"github.com/rancher/machine/libmachine/auth"
+	"github.com/rancher/machine/libmachine/drivers"
+	"github.com/rancher/machine/libmachine/engine"
+	"github.com/rancher/machine/libmachine/provision/pkgaction"
+	"github.com/rancher/machine/libmachine/provision/serviceaction"
+	"github.com/rancher/machine/libmachine/swarm"
+)
+
+// NoDockerInstall ensures that docker will not be installed when provisioning the machine
+func NoDockerInstall() {
+	SetDetector(noOpDetector{})
+}
+
+type noOpDetector struct{}
+
+func (np noOpDetector) DetectProvisioner(d drivers.Driver) (Provisioner, error) {
+	return &noOpProvisioner{
+		GenericProvisioner{
+			SSHCommander: noOpSSHCommander{},
+			Packages: []string{
+				"curl",
+			},
+			Driver: d,
+		},
+	}, nil
+}
+
+type noOpProvisioner struct {
+	GenericProvisioner
+}
+
+func (n *noOpProvisioner) String() string {
+	return "no-op"
+}
+
+func (n *noOpProvisioner) Package(_ string, _ pkgaction.PackageAction) error {
+	return nil
+}
+
+func (n *noOpProvisioner) Provision(_ swarm.Options, _ auth.Options, _ engine.Options) error {
+	return nil
+}
+
+func (n *noOpProvisioner) Service(_ string, _ serviceaction.ServiceAction) error {
+	return nil
+}
+
+func (n *noOpProvisioner) CompatibleWithHost() bool {
+	return true
+}
+
+type noOpSSHCommander struct{}
+
+func (noOp noOpSSHCommander) SSHCommand(_ string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
RKE2 will not require Docker. In preparation for this, a new `--no-docker` flag is added to the create command that will skip machine provisioning and Docker installation.

Issue:
https://github.com/rancher/rancher/issues/30597