### PR TITLE
SLES15 firewalld support

### DIFF
--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -201,6 +201,10 @@ func (provisioner *SUSEProvisioner) configureFirewall() error {
 	if _, installed := provisioner.SSHCommand("rpm -q firewalld"); installed == nil {
 		// check if firewalld is running //
 		if _, running := provisioner.SSHCommand("sudo firewall-cmd --stat"); running == nil {
+			// edge case where someone may have installed both, we default to the running firewalld
+			if len(cmds) != 0 {
+				cmds = nil
+			}
 			tcpPorts := strings.ReplaceAll(tcpPorts, ":", "-")
 			udpPorts := strings.ReplaceAll(udpPorts, ":", "-")
 			for _, port := range strings.Split(tcpPorts, " ") {


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/30717

Changes in logic to query if SuSEfirewall (SLES12) or firewalld(SLES15) is installed.

Current logic assumes if firewalld is not installed then SuSEfirewall is available and then tries to configure instance using SuseFirewall.

This causes instance provisioning to fail.

The firewall configuration logic has been fine tuned to make it more explicit and only add firewalld rules if firewalld is installed and running.

This helps cover use cases where firewalld is not available as well, and driver now no longer defaults to SuSEfirewall.

