### PR TITLE
[master] Allow skipping docker installation

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -110,8 +110,7 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 		}
 	}
 
-	log.Debug("installing docker")
-	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
+	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -142,7 +142,6 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 		}
 	}
 
-	log.Debug("Installing docker")
 	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {
 		return err
 	}

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -120,8 +120,7 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 		}
 	}
 
-	log.Info("Installing Docker...")
-	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
+	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -134,8 +134,7 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 		}
 	}
 
-	log.Info("Installing Docker...")
-	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
+	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -25,10 +25,15 @@ type DockerOptions struct {
 }
 
 func installDockerGeneric(p Provisioner, baseURL string) error {
+	if strings.EqualFold(baseURL, "none") {
+		log.Info("Skipping Docker installation")
+		return nil
+	}
 	// install docker - until cloudinit we use ubuntu everywhere so we
 	// just install it using the docker repos
+	log.Infof("Installing Docker from: %s", baseURL)
 	if output, err := p.SSHCommand(fmt.Sprintf("if ! type docker; then curl -sSL %s | sh -; fi", baseURL)); err != nil {
-		return fmt.Errorf("error installing docker: %s", output)
+		return fmt.Errorf("Error installing Docker: %s", output)
 	}
 
 	return nil


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/27646

~~As discussed, removed the docker installation step during provision. The expectation now is the user has already pre-installed everything they need to have installed docker themselves (will need to be documented).~~

Edit:
Updated provisioning to allow users to opt-in for skipping docker install by passing in `"none"` as the `engineInstallURL`, which can be easily added to the UI's dropdown of docker installation options. 
Users will now have the following options:
1. Provide no URL => Defaults to installing docker using default URL (get.docker.com)
2. Provide a URL => URL is used to install docker
3. Provide `"none"` as the URL => installing docker will be skipped
