### PR TITLE
Support openSUSE variants

### DIFF
--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -40,7 +40,7 @@ func NewSLESProvisioner(d drivers.Driver) Provisioner {
 
 func NewOpenSUSEProvisioner(d drivers.Driver) Provisioner {
 	return &SUSEProvisioner{
-		NewSystemdProvisioner("openSUSE", d),
+		NewSystemdProvisioner("opensuse", d),
 	}
 }
 
@@ -49,7 +49,7 @@ type SUSEProvisioner struct {
 }
 
 func (provisioner *SUSEProvisioner) CompatibleWithHost() bool {
-	return strings.ToLower(provisioner.OsReleaseInfo.ID) == strings.ToLower(provisioner.OsReleaseID)
+	return strings.ToLower(provisioner.OsReleaseInfo.ID) == strings.ToLower(provisioner.OsReleaseID) || strings.Contains(provisioner.OsReleaseInfo.IDLike, "opensuse")
 }
 
 func (provisioner *SUSEProvisioner) String() string {


### PR DESCRIPTION
The current OS detection code looks for openSUSE only, which no longer works given the split between Leap and Tumbleweed.

Update the relevant strings so that the driver successfully detects and provisions a cluster on all openSUSE variants.

Tested against openSUSE Leap 15.2 with an image built using [this Packer template](https://github.com/yankcrime/Rancher-Packer/tree/opensuse_leap_15.2/vSphere/opensuse_leap_15.2) and vSphere 7.0.1.