### PR TITLE
VM folder path and network assignment fix

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -275,7 +275,7 @@ func (d *Driver) createFromLibraryName() error {
 		return err
 	}
 
-	folders, err := d.datacenter.Folders(d.getCtx())
+	folder, err := d.findFolder()
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (d *Driver) createFromLibraryName() error {
 		Target: vcenter.Target{
 			ResourcePoolID: d.resourcepool.Reference().Value,
 			HostID:         hostId,
-			FolderID:       folders.VmFolder.Reference().Value,
+			FolderID:       folder.Reference().Value,
 		},
 	}
 

--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -303,15 +303,6 @@ func (d *Driver) createFromLibraryName() error {
 	if !ok {
 		return fmt.Errorf("Content Library item is not a template: %q is a %T", d.CloneFrom, item)
 	}
-
-	var nets []vcenter.NetworkMapping
-	for k, n := range d.networks {
-		nets = append(nets, vcenter.NetworkMapping{
-			Key:   k,
-			Value: n.Reference().Value,
-		})
-	}
-
 	hostId := ""
 	if d.hostsystem != nil {
 		hostId = d.hostsystem.Reference().Value
@@ -320,6 +311,30 @@ func (d *Driver) createFromLibraryName() error {
 	ds, err := d.getDatastore(&types.VirtualMachineConfigSpec{})
 	if err != nil {
 		return err
+	}
+	fr := vcenter.FilterRequest{Target: vcenter.Target{
+                        ResourcePoolID: d.resourcepool.Reference().Value,
+                        HostID:         hostId,
+                        FolderID:       folder.Reference().Value,
+        },
+        }
+
+	m := vcenter.NewManager(libManager.Client)
+	r, err := m.FilterLibraryItem(d.getCtx(), item.ID, fr)
+	if err != nil {
+                return err
+	}
+	if len(d.networks) != len(r.Networks) {
+		return fmt.Errorf("Mismatch in number of networks in content library template %s and rancher template", d.CloneFrom)
+	}
+	netIndex := 0
+	var nets []vcenter.NetworkMapping
+	for _, n := range d.networks {
+		nets = append(nets, vcenter.NetworkMapping{
+			Key:   r.Networks[netIndex],
+			Value: n.Reference().Value,
+		})
+		netIndex++
 	}
 
 	deploy := vcenter.Deploy{
@@ -336,8 +351,6 @@ func (d *Driver) createFromLibraryName() error {
 			FolderID:       folder.Reference().Value,
 		},
 	}
-
-	m := vcenter.NewManager(libManager.Client)
 
 	ref, err := m.DeployLibraryItem(d.getCtx(), item.ID, deploy)
 	if err != nil {


### PR DESCRIPTION
Ref: https://github.com/rancher/rancher/issues/31407

```
Problem: VMs deployed via the content library will always land in the root folder instead of the custom folder passed by driver.
Root cause:  createFromLibraryName() uses d.datacenter.Folders(d.getCtx()) which won't return the proper folder path.
Fix: A PR was pushed in the past https://github.com/rancher/machine/pull/61 , but this was not included in createFromLibraryName() 
```
Ref: https://github.com/rancher/rancher/issues/31408

```
Problem: VMs deployed via content library will not map network interfaces properly 
Root cause:  FilterLibraryItem - https://pkg.go.dev/github.com/vmware/govmomi/vapi/vcenter#Manager.FilterLibraryItem was missing in the code path which resulted in ignoring network assignments 
Fix: The OVF template needs to be fetched and then the existing interfaces in the OVF template need to be mapped with the supplied networks from the driver.
    (Deployment of VM from the content library via UI permits only network mapping change and no network addition or deletion is possible, so the same logic applied here too)
```



