### PR TITLE
Update default instance type

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -36,7 +36,7 @@ const (
 	machineTag                  = "rancher-nodes"
 	defaultAmiId                = "ami-c60b90d1"
 	defaultRegion               = "us-east-1"
-	defaultInstanceType         = "t2.micro"
+	defaultInstanceType         = "t3.micro"
 	defaultRootSize             = 16
 	defaultVolumeType           = "gp2"
 	defaultZone                 = "a"


### PR DESCRIPTION
**Problem:**
Prior, ec2 create requests using the default instance type could fail due to certain regions not supporting it, particularly me-south-1.

**Solution:**
Now, the default instance type has been changed to a value supported by the aforementioned region.

**Issue:**
https://github.com/rancher/rancher/issues/31980