### PR TITLE
Move around code to install curl

### DIFF
--- a/libmachine/provision/amazonlinux.go
+++ b/libmachine/provision/amazonlinux.go
@@ -23,7 +23,7 @@ func init() {
 
 func NewAmazonLinuxProvisioner(d drivers.Driver) Provisioner {
 	return &AmazonLinuxProvisioner{
-		NewSystemdProvisioner("amzn", d),
+		NewSystemdProvisioner("amzn", d, false),
 	}
 }
 

--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -21,7 +21,7 @@ func init() {
 
 func NewArchProvisioner(d drivers.Driver) Provisioner {
 	return &ArchProvisioner{
-		NewSystemdProvisioner("arch", d),
+		NewSystemdProvisioner("arch", d, false),
 	}
 }
 

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -32,7 +32,7 @@ func init() {
 
 func NewCoreOSProvisioner(d drivers.Driver) Provisioner {
 	return &CoreOSProvisioner{
-		NewSystemdProvisioner("coreos", d),
+		NewSystemdProvisioner("coreos", d, false),
 	}
 }
 

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -21,7 +21,7 @@ func init() {
 
 func NewDebianProvisioner(d drivers.Driver) Provisioner {
 	return &DebianProvisioner{
-		NewSystemdProvisioner("debian", d),
+		NewSystemdProvisioner("debian", d, true),
 	}
 }
 
@@ -101,13 +101,6 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 	log.Debug("setting hostname")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
-	}
-
-	log.Debug("installing base packages")
-	for _, pkg := range provisioner.Packages {
-		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
-			return err
-		}
 	}
 
 	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {

--- a/libmachine/provision/fedora_coreos.go
+++ b/libmachine/provision/fedora_coreos.go
@@ -22,7 +22,7 @@ func init() {
 // NewFedoraCoreOSProvisioner creates a new provisioner for a driver
 func NewFedoraCoreOSProvisioner(d drivers.Driver) Provisioner {
 	return &FedoraCoreOSProvisioner{
-		NewSystemdProvisioner("fedora", d),
+		NewSystemdProvisioner("fedora", d, false),
 	}
 }
 

--- a/libmachine/provision/photonos.go
+++ b/libmachine/provision/photonos.go
@@ -26,7 +26,7 @@ func init() {
 // NewPhotonOSProvisioner creates a new provisioner for a driver
 func NewPhotonOSProvisioner(d drivers.Driver) Provisioner {
 	return &PhotonOSProvisioner{
-		NewSystemdProvisioner("photon", d),
+		NewSystemdProvisioner("photon", d, false),
 	}
 }
 

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -28,19 +28,19 @@ func init() {
 
 func NewSLEDProvisioner(d drivers.Driver) Provisioner {
 	return &SUSEProvisioner{
-		NewSystemdProvisioner("sled", d),
+		NewSystemdProvisioner("sled", d, true),
 	}
 }
 
 func NewSLESProvisioner(d drivers.Driver) Provisioner {
 	return &SUSEProvisioner{
-		NewSystemdProvisioner("sles", d),
+		NewSystemdProvisioner("sles", d, true),
 	}
 }
 
 func NewOpenSUSEProvisioner(d drivers.Driver) Provisioner {
 	return &SUSEProvisioner{
-		NewSystemdProvisioner("opensuse", d),
+		NewSystemdProvisioner("opensuse", d, true),
 	}
 }
 
@@ -133,13 +133,6 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 	log.Debug("Setting hostname")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
-	}
-
-	log.Debug("Installing base packages")
-	for _, pkg := range provisioner.Packages {
-		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
-			return err
-		}
 	}
 
 	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -22,7 +22,7 @@ func init() {
 
 func NewUbuntuSystemdProvisioner(d drivers.Driver) Provisioner {
 	return &UbuntuSystemdProvisioner{
-		NewSystemdProvisioner("ubuntu", d),
+		NewSystemdProvisioner("ubuntu", d, true),
 	}
 }
 
@@ -111,13 +111,6 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 	log.Debug("setting hostname")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
-	}
-
-	log.Debug("installing base packages")
-	for _, pkg := range provisioner.Packages {
-		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
-			return err
-		}
 	}
 
 	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -128,12 +128,6 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 		return err
 	}
 
-	for _, pkg := range provisioner.Packages {
-		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
-			return err
-		}
-	}
-
 	if err := installDockerGeneric(provisioner, provisioner.EngineOptions.InstallURL); err != nil {
 		return err
 	}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/machine/libmachine/engine"
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/rancher/machine/libmachine/mcnutils"
+	"github.com/rancher/machine/libmachine/provision/pkgaction"
 	"github.com/rancher/machine/libmachine/provision/serviceaction"
 )
 
@@ -29,8 +30,14 @@ func installDockerGeneric(p Provisioner, baseURL string) error {
 		log.Info("Skipping Docker installation")
 		return nil
 	}
-	// install docker - until cloudinit we use ubuntu everywhere so we
-	// just install it using the docker repos
+
+	for _, pkg := range p.GetPackages() {
+		log.Debugf("installing base package: name=%s", pkg)
+		if err := p.Package(pkg, pkgaction.Install); err != nil {
+			return err
+		}
+	}
+
 	log.Infof("Installing Docker from: %s", baseURL)
 	if output, err := p.SSHCommand(fmt.Sprintf("if ! type docker; then curl -sSL %s | sh -; fi", baseURL)); err != nil {
 		return fmt.Errorf("Error installing Docker: %s", output)


### PR DESCRIPTION
Sorry I'm not a golang programmer - normally more in the python + php ecosystem - so apologies in advance if this is some sort of monster PR.

This follows up from https://github.com/rancher/machine/pull/109 which whilst it did the job of allowing us to disable the docker install. Still didn't clear out the curl install that is run as a precursor. This means airgaps or installs with a proxy in front still have issues. Sample issue below (although there's a couple more in the tracker)

https://github.com/rancher/rancher/issues/32078