### PR TITLE
Stop looking for blank google userdata file

### DIFF
--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -262,12 +262,13 @@ func (d *Driver) PreCreateCheck() error {
 		}
 	}
 
-	// Read the userdata file
-	file, err := ioutil.ReadFile(d.Userdata)
-	if err != nil {
-		return fmt.Errorf("cannot read userdata file %v: %v", d.Userdata, err)
+	if d.Userdata != "" {
+		file, err := ioutil.ReadFile(d.Userdata)
+		if err != nil {
+			return fmt.Errorf("cannot read userdata file %v: %v", d.Userdata, err)
+		}
+		d.Userdata = string(file)
 	}
-	d.Userdata = string(file)
 
 	return nil
 }


### PR DESCRIPTION
The changes to add userdate to the Google driver mistakenly always tried
to read the userdata file. Now, the driver will only look for the
userdata file when one is passed to the driver.