### PR TITLE
Add image purchase plan to Azure driver

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -211,7 +211,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:  flAzurePlan,
-			Usage: "Purchase plan for Azure Virtual Machine (in <name>:<publisher>:<product> format)",
+			Usage: "Purchase plan for Azure Virtual Machine (in <publisher>:<product>:<plan> format)",
 		},
 		mcnflag.BoolFlag{
 			Name:   flAzureManagedDisks,

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -63,6 +63,7 @@ const (
 	flAzureClientID          = "azure-client-id"
 	flAzureClientSecret      = "azure-client-secret"
 	flAzureNSG               = "azure-nsg"
+	flAzurePlan              = "azure-plan"
 )
 
 const (
@@ -90,6 +91,7 @@ type Driver struct {
 	SubnetPrefix    string
 	AvailabilitySet string
 	NSG             string
+	Plan            string
 	ManagedDisks    bool
 	FaultCount      int
 	UpdateCount     int
@@ -206,6 +208,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine)",
 			EnvVar: "AZURE_NSG",
 			Value:  "",
+		},
+		mcnflag.StringFlag{
+			Name:  flAzurePlan,
+			Usage: "Purchase plan for Azure Virtual Machine (in <name>:<publisher>:<product> format)",
 		},
 		mcnflag.BoolFlag{
 			Name:   flAzureManagedDisks,
@@ -324,6 +330,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.UpdateCount = fl.Int(flAzureUpdateDomainCount)
 	d.DiskSize = fl.Int(flAzureDiskSize)
 	d.NSG = fl.String(flAzureNSG)
+	d.Plan = fl.String(flAzurePlan)
 
 	d.ClientID = fl.String(flAzureClientID)
 	d.ClientSecret = fl.String(flAzureClientSecret)
@@ -451,7 +458,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 	if err := c.CreateVirtualMachine(ctx, d.ResourceGroup, d.naming().VM(), d.Location, d.Size, d.deploymentCtx.AvailabilitySetID,
-		d.deploymentCtx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.deploymentCtx.SSHPublicKey, d.Image, customData, d.deploymentCtx.StorageAccount,
+		d.deploymentCtx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.deploymentCtx.SSHPublicKey, d.Image, d.Plan, customData, d.deploymentCtx.StorageAccount,
 		d.ManagedDisks, d.StorageType, int32(d.DiskSize)); err != nil {
 		return err
 	}

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -662,12 +662,13 @@ func (a AzureClient) getImageReference(ctx context.Context, image, location stri
 	return nil, fmt.Errorf("image provided must be an image URN or an ARM resource identifier")
 }
 
+// getImagePurchasePlan parses a publisher:product:plan as a image purchase plan reference
 func (a AzureClient) getImagePurchasePlan(ctx context.Context, plan string) (*compute.Plan, error) {
 	if urn := strings.Split(plan, ":"); len(urn) == 3 {
 		return &compute.Plan{
-			Name:      to.StringPtr(urn[0]),
-			Publisher: to.StringPtr(urn[1]),
-			Product:   to.StringPtr(urn[2]),
+			Publisher: to.StringPtr(urn[0]),
+			Product:   to.StringPtr(urn[1]),
+			Name:      to.StringPtr(urn[2]),
 		}, nil
 	}
 	return nil, fmt.Errorf("plan provided must be an valid purchase plan identifier")


### PR DESCRIPTION
Problem:  Creating a virtual machine from Marketplace image requires Plan information in the request.

Adds a new flag, in the `<publisher>:<product>:<plan>` format, to provide marketplace purchase plan information when provisioning Azure vms.

Issues: 
- rancher/rancher#27854
- rancher/rancher#22927