### PR TITLE
Set proper exit code on pod exit

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-self=$$
 termination_log="/dev/termination-log"
 
 for i; do
@@ -23,10 +22,10 @@ if [ -n "$driver_url" ]; then
   if [ -z "$driver_hash" ]; then
     echo "driver-hash not provided, will not verify after download" | tee -a $termination_log
   fi
-  if ! { download_driver.sh "$driver_url" "$driver_hash" 2>&1 || kill $self; } | tee -a $termination_log; then
+  if ! { { { { download_driver.sh "$driver_url" "$driver_hash" 2>&1; echo $? >&3; } | tee -a $termination_log >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1; then
    echo "download of driver from $driver_url failed" | tee -a $termination_log
    exit 1
   fi
 fi
 
-{ rancher-machine $@ 2>&1 || kill $self; } | tee -a $termination_log
+{ { { { rancher-machine $@ 2>&1; echo $? >&3; } | tee -a $termination_log >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1


### PR DESCRIPTION
If the rancher-machine image is run in a pod, then the exit code of the
pod was not being properly set if the rancher-machine call failed (set
to 0 even though rancher-machine exited with code 1). The changes to the
entrypoint script properly sets the exit code if the rancher-machine
command fails while still passing the ouput of the command to tee.