### PR TITLE
Make SSH timeout configurable (Rancher #32526)

### DIFF
--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -2,10 +2,18 @@ package drivers
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/rancher/machine/libmachine/mcnutils"
 	"github.com/rancher/machine/libmachine/ssh"
+)
+
+const (
+	DefaultSSHAttempts      = 60
+	DefaultSSHRetryInverval = 3
 )
 
 func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
@@ -62,8 +70,37 @@ func sshAvailableFunc(d Driver) func() bool {
 }
 
 func WaitForSSH(d Driver) error {
-	// Try to dial SSH for 30 seconds before timing out.
-	if err := mcnutils.WaitFor(sshAvailableFunc(d)); err != nil {
+	// Try to dial SSH for sshRetryInterval seconds before timing out.
+	var maxAttempts int
+	var retryInterval int
+	var err error
+
+	if maxAttemptsStr, envVarPresent := os.LookupEnv("MACHINE_SSH_ATTEMPTS"); envVarPresent {
+		if maxAttempts, err = strconv.Atoi(maxAttemptsStr); err != nil {
+			log.Errorf("Value '%s' from environment variable MACHINE_SSH_ATTEMPTS could not be parsed, "+
+				"setting default value (%d)",
+				maxAttemptsStr, DefaultSSHAttempts)
+			maxAttempts = DefaultSSHAttempts
+		}
+	} else {
+		maxAttempts = DefaultSSHAttempts
+	}
+
+	if retryIntervalStr, envVarPresent := os.LookupEnv("MACHINE_SSH_RETRY_INTERVAL"); envVarPresent {
+		if retryInterval, err = strconv.Atoi(retryIntervalStr); err != nil {
+			log.Errorf("Value '%s' from environment variable MACHINE_SSH_RETRY_INTERVAL could not be parsed, "+
+				"setting default value (%d)",
+				retryIntervalStr, DefaultSSHRetryInverval)
+			retryInterval = DefaultSSHRetryInverval
+		}
+	} else {
+		retryInterval = DefaultSSHRetryInverval
+	}
+
+	interval := time.Duration(retryInterval * int(time.Second))
+	log.Infof("Waiting for SSH to become available (maximum attempts: %d, interval between attempts: %s)",
+		maxAttempts, interval.String())
+	if err := mcnutils.WaitForSpecific(sshAvailableFunc(d), maxAttempts, interval); err != nil {
 		return fmt.Errorf("Too many retries waiting for SSH to be available.  Last error: %s", err)
 	}
 	return nil

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -57,10 +57,6 @@ type Auth struct {
 type ClientType string
 
 const (
-	maxDialAttempts = 10
-)
-
-const (
 	External ClientType = "external"
 	Native   ClientType = "native"
 )


### PR DESCRIPTION
This is my proposed solution for https://github.com/rancher/rancher/issues/32526. While making it, I considered several routes:

- Adding a new command line parameter to rancher-machine: Not feasible, since the only way to pass any options to the drivers seems to be via the Drivers interface. Changing this interface would risk breaking existing docker-machine drivers for Rancher. 
- Adding the driver options "ssh-max-attempts" and "ssh-retry-interval" to every single driver, e.g. "amazonec2-ssh-max-attempts", "azure-ssh-max-attempts" etc. That would be an ugly amount duplication of both code and functionality.

The only practical method I found was to introduce two new environment variables:
- MACHINE_SSH_ATTEMPTS: Specifies the maximum number of attempts to try to get an SSH connection once the provider reports a new node as provisioned. Defaults to 60 (=the value used in mcnutils/utils.go)
- MACHINE_SSH_RETRY_INTERVAL: Number of seconds between each attempt, defaults to the current value of 3 seconds.

