### PR TITLE
Specify the first Interface when calling vm.WaitForNetIP().

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -181,7 +181,7 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	configuredMacIPs, err := vm.WaitForNetIP(d.getCtx(), false)
+	configuredMacIPs, err := vm.WaitForNetIP(d.getCtx(), false, "ethernet-0")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When using multiple networks in vSphere, the IP address used by rancher-machine as the ssh connection destination becomes random.

https://github.com/rancher/rancher/issues/32205

This PR will allow the rancher-machine to use the IP address of the first NIC for ssh connectivity.

https://pkg.go.dev/github.com/vmware/govmomi/object#VirtualMachine.WaitForNetIP

