### PR TITLE
add AvailabilityZone param to VolumeCreate opts

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -136,6 +136,9 @@ func (c *GenericClient) VolumeCreate(d *Driver) (string, error) {
 	if d.VolumeType != "" {
 		opts.VolumeType = d.VolumeType
 	}
+	if d.AvailabilityZone != "" {
+		opts.AvailabilityZone = d.AvailabilityZone
+	}
 	vol, err := volumes.Create(c.BlockStorage, opts).Extract()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

The PR adds the availability_zone parameter to the VolumeCreate function if the parameter is not empty.

## Related issue(s)

https://github.com/rancher/rancher/issues/32775