### PR TITLE
Fix cpu & memory change in content library

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -338,7 +338,23 @@ func (d *Driver) createFromLibraryName() error {
 		return err
 	}
 
+	// At this point, the VM is deployed from content library with defaults from template
+	// Reconfiguration of the VM based on driver inputs follows
+
 	vm := obj.(*object.VirtualMachine)
+	spec := types.VirtualMachineConfigSpec{
+		NumCPUs:    int32(d.CPU),
+		MemoryMB:   int64(d.Memory),
+		VAppConfig: d.getVAppConfig(),
+        }
+
+	task, err := vm.Reconfigure(d.getCtx(), spec)
+
+	err = task.Wait(d.getCtx())
+	if err != nil {
+		return err
+	}
+
 	if err := d.resizeDisk(vm); err != nil {
 		return err
 	}

--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -346,9 +346,12 @@ func (d *Driver) createFromLibraryName() error {
 		NumCPUs:    int32(d.CPU),
 		MemoryMB:   int64(d.Memory),
 		VAppConfig: d.getVAppConfig(),
-        }
+	}
 
 	task, err := vm.Reconfigure(d.getCtx(), spec)
+	if err != nil {
+		return err
+	}
 
 	err = task.Wait(d.getCtx())
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/32761 
The VM gets deployed from the content library was taking defaults from
OVF template instead of driver input. Added code to reconfigure VM
based on the input from the driver.