### PR TITLE
Add tenant ID to Azure driver

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -38,6 +38,7 @@ const (
 const (
 	flAzureEnvironment       = "azure-environment"
 	flAzureSubscriptionID    = "azure-subscription-id"
+	flAzureTenantID          = "azure-tenant-id"
 	flAzureResourceGroup     = "azure-resource-group"
 	flAzureSSHUser           = "azure-ssh-user"
 	flAzureDockerPort        = "azure-docker-port"
@@ -79,6 +80,7 @@ type Driver struct {
 
 	Environment    string
 	SubscriptionID string
+	TenantID       string
 	ResourceGroup  string
 
 	DockerPort      int
@@ -140,6 +142,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   flAzureSubscriptionID,
 			Usage:  "Azure Subscription ID",
 			EnvVar: "AZURE_SUBSCRIPTION_ID",
+		},
+		mcnflag.StringFlag{
+			Name:   flAzureTenantID,
+			Usage:  "Azure Tenant ID",
+			EnvVar: "AZURE_TENANT_ID",
 		},
 		mcnflag.StringFlag{
 			Name:   flAzureResourceGroup,
@@ -327,6 +334,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 
 	d.ClientID = fl.String(flAzureClientID)
 	d.ClientSecret = fl.String(flAzureClientSecret)
+	d.TenantID = fl.String(flAzureTenantID)
 
 	// Set flags on the BaseDriver
 	d.BaseDriver.SSHPort = sshPort

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -49,13 +49,13 @@ func (d *Driver) newAzureClient(ctx context.Context) (*azureutil.AzureClient, er
 	)
 	if d.ClientID != "" && d.ClientSecret != "" { // use client credentials auth
 		log.Debug("Using Azure client credentials.")
-		authorizer, err = azureutil.AuthenticateClientCredentials(ctx, env, d.SubscriptionID, d.ClientID, d.ClientSecret)
+		authorizer, err = azureutil.AuthenticateClientCredentials(ctx, env, d.SubscriptionID, d.TenantID, d.ClientID, d.ClientSecret)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to authenticate using client credentials: %+v", err)
 		}
 	} else { // use browser-based device auth
 		log.Debug("Using Azure device flow authentication.")
-		authorizer, err = azureutil.AuthenticateDeviceFlow(ctx, env, d.SubscriptionID)
+		authorizer, err = azureutil.AuthenticateDeviceFlow(ctx, env, d.SubscriptionID, d.TenantID)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating Azure client: %v", err)
 		}


### PR DESCRIPTION
The Azure driver currently uses an interesting way of getting the tenant ID from the subscription ID. A flag is added to allow a user or Rancher to pass the desired tenant ID to the driver.

Issue:
https://github.com/rancher/rancher/issues/31014