### PR TITLE
Only create volume when actually required

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -848,8 +848,10 @@ func (d *Driver) createMachine() error {
 	if err := d.initCompute(); err != nil {
 		return err
 	}
-	if err := d.initBlockStorage(); err != nil {
-		return err
+	if d.BootFromVolume == true || d.VolumeSize > 0 {
+		if err := d.initBlockStorage(); err != nil {
+			return err
+		}
 	}
 	instanceID, err := d.client.CreateInstance(d)
 	if err != nil {


### PR DESCRIPTION
When creating an instance with the openstack driver, the Block storage APIs are invoked even if block storage has specifically not been requested. This change adds a condition that only invokes the Block storage API if required.

This was introduced [here](https://github.com/rancher/machine/pull/93). While the original change should work in most environments, I have an openstack environment that does not implement Cinder, and so the creation of the rancher-machine fails.

Fixes https://github.com/rancher/rancher/issues/33124
