### PR TITLE
Handle spaces in commandline arguments

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -12,7 +12,15 @@ for i; do
       driver_hash=${i##--driver-hash=}
     ;;
     *)
-      set -- "$@" "$i"
+      # Breaking up arguments that are passed to rancher-machine allows for handling values with spaces.
+      flag=${i%%=*}
+      value=${i#--*=}
+      if [ "$flag" = "$value" ]; then
+        # If flag and value are the same, then the argument that was passed doesn't have an equal-sign and can be passed as-is.
+        set -- "$@" "$flag"
+      else
+        set -- "$@" "$flag" "$value"
+      fi
     ;;
   esac
 done
@@ -28,4 +36,4 @@ if [ -n "$driver_url" ]; then
   fi
 fi
 
-{ { { { rancher-machine $@ 2>&1; echo $? >&3; } | tee -a $termination_log >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1
+{ { { { rancher-machine "$@" 2>&1; echo $? >&3; } | tee -a $termination_log >&4; } 3>&1; } | { read xs; exit $xs; } } 4>&1


### PR DESCRIPTION
The command line arguments to rancher-machine were being passes as `--driver=great_driver`. However, this did not allow for handling cases where the value had a space in it.

Now, by splitting the these up to `--driver` `great_driver`, we are able to quote the values, which allows for handling of spaces.

Issue:
https://github.com/rancher/rancher/issues/33867