### PR TITLE
Add more robust custom script upload when using SSH

### DIFF
--- a/libmachine/provision/custom_script.go
+++ b/libmachine/provision/custom_script.go
@@ -27,7 +27,10 @@ func WithCustomScript(provisioner Provisioner, customScriptPath string) error {
 		return fmt.Errorf("unable to read file %s: %v", customScriptPath, err)
 	}
 
-	if output, err := provisioner.SSHCommand(fmt.Sprintf("echo \"%v\" | sh -", string(customScriptContents))); err != nil {
+	if output, err := provisioner.SSHCommand(fmt.Sprintf("cat <<'OEOF' >/tmp/install_script.sh\n%s\nOEOF", string(customScriptContents))); err != nil {
+		return fmt.Errorf("error uploading custom script: output: %s, error: %s", output, err)
+	}
+	if output, err := provisioner.SSHCommand("sh /tmp/install_script.sh"); err != nil {
 		return fmt.Errorf("error running custom script: output: %s, error: %s", output, err)
 	}
 


### PR DESCRIPTION
Previously, the method of running the custom install script on the
remote machine was faulty for anything besides a simple script. Now, the
file upload and the running of the script are done in two separate steps
to handle the more complicated script.

Issue:
https://github.com/rancher/rancher/issues/32371