### PR TITLE
Install ssh client in the docker image

### DIFF
--- a/libmachine/provision/custom_script.go
+++ b/libmachine/provision/custom_script.go
@@ -30,7 +30,7 @@ func WithCustomScript(provisioner Provisioner, customScriptPath string) error {
 	if output, err := provisioner.SSHCommand(fmt.Sprintf("cat <<'OEOF' >/tmp/install_script.sh\n%s\nOEOF", string(customScriptContents))); err != nil {
 		return fmt.Errorf("error uploading custom script: output: %s, error: %s", output, err)
 	}
-	if output, err := provisioner.SSHCommand("sh /tmp/install_script.sh"); err != nil {
+	if output, err := provisioner.SSHCommand("sudo sh /tmp/install_script.sh"); err != nil {
 		return fmt.Errorf("error running custom script: output: %s, error: %s", output, err)
 	}
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update -y && \
-    microdnf install unzip file tar gzip && \
+    microdnf install unzip file tar gzip openssh-clients && \
     rm -rf /var/cache/yum
 
 WORKDIR /root


### PR DESCRIPTION
For some reason, the Go Native SSH implementation is not playing well
when run in Kubernetes. This change will install the ssh command into
the image so that the rancher-machine binary will use that instead.

Issue:
https://github.com/rancher/rancher/issues/33865