### PR TITLE
Fix: Openstack node provisioning fails with floating ip assignment

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -49,7 +49,9 @@ type Client interface {
 	GetFlavorID(d *Driver) (string, error)
 	GetImageID(d *Driver) (string, error)
 	AssignFloatingIP(d *Driver, floatingIP *FloatingIP) error
+	DeleteFloatingIP(d *Driver, floatingIP *FloatingIP) error
 	GetFloatingIPs(d *Driver) ([]FloatingIP, error)
+	GetFloatingIP(d *Driver, ip string) (*FloatingIP, error)
 	GetFloatingIPPoolID(d *Driver) (string, error)
 	GetInstancePortID(d *Driver) (string, error)
 	VolumeCreate(d *Driver) (string, error)
@@ -451,11 +453,47 @@ func (c *GenericClient) assignNeutronFloatingIP(d *Driver, floatingIP *FloatingI
 	return nil
 }
 
+func (c *GenericClient) DeleteFloatingIP(d *Driver, floatingIP *FloatingIP) error {
+	if d.ComputeNetwork {
+		// Nova network is is deprecated in OpenStack
+		// https://docs.openstack.org/nova/rocky/admin/networking-nova.html
+		log.Warn("Detected that you use Nova network. Floating IP will not be removed, please do so manually if necessary")
+		return nil
+	}
+	return c.deleteNeutronFloatingIP(d, floatingIP)
+}
+
+func (c *GenericClient) deleteNeutronFloatingIP(d *Driver, floatingIP *FloatingIP) error {
+	err := floatingips.Delete(c.Network, floatingIP.Id).ExtractErr()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *GenericClient) GetFloatingIPs(d *Driver) ([]FloatingIP, error) {
 	if d.ComputeNetwork {
 		return c.getNovaNetworkFloatingIPs(d)
 	}
-	return c.getNeutronNetworkFloatingIPs(d)
+	return c.getNeutronNetworkFloatingIPs(d, nil)
+}
+
+func (c *GenericClient) GetFloatingIP(d *Driver, ip string) (*FloatingIP, error) {
+	if d.ComputeNetwork {
+		return nil, fmt.Errorf("operation not supported for nova networks")
+	}
+	opts := &floatingips.ListOpts{
+		FloatingIP: ip,
+	}
+
+	ips, err := c.getNeutronNetworkFloatingIPs(d, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, nil
+	}
+	return &ips[0], nil
 }
 
 func (c *GenericClient) getNovaNetworkFloatingIPs(d *Driver) ([]FloatingIP, error) {
@@ -480,15 +518,23 @@ func (c *GenericClient) getNovaNetworkFloatingIPs(d *Driver) ([]FloatingIP, erro
 	return ips, err
 }
 
-func (c *GenericClient) getNeutronNetworkFloatingIPs(d *Driver) ([]FloatingIP, error) {
+func (c *GenericClient) getNeutronNetworkFloatingIPs(d *Driver, opts *floatingips.ListOpts) ([]FloatingIP, error) {
 	log.Debug("Listing floating IPs", map[string]string{
 		"FloatingNetworkId": d.FloatingIpPoolId,
 		"TenantID":          d.TenantId,
 	})
-	pager := floatingips.List(c.Network, floatingips.ListOpts{
-		FloatingNetworkID: d.FloatingIpPoolId,
-		TenantID:          d.TenantId,
-	})
+
+	if opts != nil {
+		opts.FloatingNetworkID = d.FloatingIpPoolId
+		opts.TenantID = d.TenantId
+	} else {
+		opts = &floatingips.ListOpts{
+			FloatingNetworkID: d.FloatingIpPoolId,
+			TenantID:          d.TenantId,
+		}
+	}
+
+	pager := floatingips.List(c.Network, *opts)
 
 	ips := []FloatingIP{}
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -454,7 +454,7 @@ func (d *Driver) GetIP() (string, error) {
 	}
 
 	// Looking for the IP address in a retry loop to deal with OpenStack latency
-	for retryCount := 0; retryCount < 200; retryCount++ {
+	for retryCount := 0; retryCount < 5; retryCount++ {
 		addresses, err := d.client.GetInstanceIPAddresses(d)
 		if err != nil {
 			return "", err
@@ -584,6 +584,25 @@ func (d *Driver) Kill() error {
 func (d *Driver) Remove() error {
 	log.Debug("deleting instance...", map[string]string{"MachineId": d.MachineId})
 	log.Info("Deleting OpenStack instance...")
+
+	if err := d.resolveIds(); err != nil {
+		return err
+	}
+
+	if d.FloatingIpPool != "" && d.IPAddress != "" && !d.ComputeNetwork {
+		floatingIP, err := d.client.GetFloatingIP(d, d.IPAddress)
+		if err != nil {
+			return err
+		}
+
+		if floatingIP != nil {
+			log.Debug("Deleting Floating IP: ", map[string]string{"floatingIP": floatingIP.Ip})
+			if err := d.client.DeleteFloatingIP(d, floatingIP); err != nil {
+				return err
+			}
+		}
+	}
+
 	if err := d.initCompute(); err != nil {
 		return err
 	}
@@ -926,35 +945,8 @@ func (d *Driver) assignFloatingIP() error {
 		return err
 	}
 
-	ips, err := d.client.GetFloatingIPs(d)
-	if err != nil {
-		return err
-	}
-
-	var floatingIP *FloatingIP
-
-	log.Debugf("Looking for an available floating IP", map[string]string{
-		"MachineId": d.MachineId,
-		"Pool":      d.FloatingIpPool,
-	})
-
-	for _, ip := range ips {
-		if ip.PortId == "" {
-			log.Debug("Available floating IP found", map[string]string{
-				"MachineId": d.MachineId,
-				"IP":        ip.Ip,
-			})
-			floatingIP = &ip
-			break
-		}
-	}
-
-	if floatingIP == nil {
-		floatingIP = &FloatingIP{}
-		log.Debug("No available floating IP found. Allocating a new one...", map[string]string{"MachineId": d.MachineId})
-	} else {
-		log.Debug("Assigning floating IP to the instance", map[string]string{"MachineId": d.MachineId})
-	}
+	floatingIP := &FloatingIP{}
+	log.Debug("Allocating a new floating IP...", map[string]string{"MachineId": d.MachineId})
 
 	if err := d.client.AssignFloatingIP(d, floatingIP); err != nil {
 		return err


### PR DESCRIPTION
This PR fixes the issue that causes Openstack node creation to fail due to a race condition in the floating IP address handling. See https://github.com/rancher/rancher/issues/27864

Further discussion of the issue can be found here: https://github.com/docker/machine/issues/4038

Note that the code changes are entire limited to the Openstack driver package.

PR has been tested and fix validated using Rancher 2.5.9 and RH Openstack 16