### PR TITLE
Fix get user data from tmpfile

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -531,8 +531,13 @@ func updateUserdataFile(driverOpts *rpcdriver.RPCFlags, userdataFlag, customInst
 	if err := replaceUserdataFile(userdataContent, customScriptContent, modifiedUserdataFile); err != nil {
 		return err
 	}
-
-	driverOpts.Values[userdataFlag] = modifiedUserdataFile.Name()
+	
+	readUserData, err := ioutil.ReadFile(modifiedUserdataFile.Name())
+	if err != nil {
+		return err
+	}
+	
+	driverOpts.Values[userdataFlag] = string(readUserData)
 
 	return nil
 }


### PR DESCRIPTION
Fix https://github.com/rancher/rancher/issues/34782


`user-data.txt` contains the name of the temporary file
`cat /var/lib/cloud/instances/*/user-data.txt`
```
/tmp/modified-user-data*****
```