### PR TITLE
add OS support to vsphere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cover
 /dist
 *.swp
 rancher-machine
+.DS_STORE

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -1,19 +1,18 @@
 package amazonec2
 
 import (
-	"github.com/rancher/machine/version"
 	"testing"
 
 	"errors"
-	"reflect"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/rancher/machine/commands/commandstest"
+	"github.com/rancher/machine/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -27,9 +26,9 @@ const (
 var (
 	/* This test resource should be used in tests that set their own IpPermissions */
 	securityGroup = &ec2.SecurityGroup{
-		GroupName:     aws.String("test-group"),
-		GroupId:       aws.String("12345"),
-		VpcId:         aws.String("12345"),
+		GroupName: aws.String("test-group"),
+		GroupId:   aws.String("12345"),
+		VpcId:     aws.String("12345"),
 	}
 
 	/* This test resource should only be used in tests that do not update IpPermissions */

--- a/drivers/vmwarevsphere/vm.go
+++ b/drivers/vmwarevsphere/vm.go
@@ -128,6 +128,8 @@ func (d *Driver) addNetworks(vm *object.VirtualMachine, networks map[string]obje
 	return nil
 }
 
+// provisionVm provisions a legacy VM
+// legacy Windows VMs are not supported
 func (d *Driver) provisionVm(vm *object.VirtualMachine) error {
 	log.Infof("Provisioning certs and ssh keys...")
 
@@ -157,6 +159,10 @@ func (d *Driver) provisionVm(vm *object.VirtualMachine) error {
 	auth := NewAuthFlag(d.SSHUser, d.SSHPassword)
 	flag := FileAttrFlag{}
 	flag.SetPerms(0, 0, 660)
+
+	if d.OS != defaultMachineOS {
+		return fmt.Errorf("provisionVm: Machine OS [%s] is not supported for Legacy VMs", d.OS)
+	}
 
 	tmpDir, err := fileman.CreateTemporaryDirectory(d.getCtx(), auth.Auth(), "docker_", "", "/tmp")
 	if err != nil {
@@ -195,7 +201,6 @@ func (d *Driver) provisionVm(vm *object.VirtualMachine) error {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -216,7 +221,6 @@ func (d *Driver) addConfigParams(vm *object.VirtualMachine) error {
 			})
 		}
 	}
-
 	return d.applyOpts(vm, opts)
 }
 
@@ -224,7 +228,6 @@ func (d *Driver) applyOpts(vm *object.VirtualMachine, opts []types.BaseOptionVal
 	if len(opts) == 0 {
 		return nil
 	}
-
 	task, err := vm.Reconfigure(d.getCtx(), types.VirtualMachineConfigSpec{
 		ExtraConfig: opts,
 	})
@@ -260,7 +263,6 @@ func (d *Driver) addTags(vm *object.VirtualMachine) error {
 
 		tagsManager.AttachTag(d.getCtx(), tag.ID, vm)
 	}
-
 	return nil
 }
 
@@ -290,7 +292,6 @@ func (d *Driver) addCustomAttributes(vm *object.VirtualMachine) error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -72,15 +72,15 @@ type Driver struct {
 	CloneFrom              string
 	SSHPassword            string
 	SSHUserGroup           string
-
-	vms          map[string]*object.VirtualMachine
-	soap         *govmomi.Client
-	ctx          context.Context
-	finder       *find.Finder
-	datacenter   *object.Datacenter
-	networks     map[string]object.NetworkReference
-	hostsystem   *object.HostSystem
-	resourcepool *object.ResourcePool
+	OS                     string
+	vms                    map[string]*object.VirtualMachine
+	soap                   *govmomi.Client
+	ctx                    context.Context
+	finder                 *find.Finder
+	datacenter             *object.Datacenter
+	networks               map[string]object.NetworkReference
+	hostsystem             *object.HostSystem
+	resourcepool           *object.ResourcePool
 }
 
 const (
@@ -92,6 +92,8 @@ const (
 	defaultMemory       = 2048
 	defaultDiskSize     = 20480
 	defaultSDKPort      = 443
+	defaultMachineOS    = "linux"
+	WindowsMachineOS    = "windows"
 
 	creationTypeVM      = "vm"
 	creationTypeTmpl    = "template"

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -120,10 +120,26 @@ func DriverUserdataFlag(d Driver) string {
 	return ""
 }
 
+// DriverOSFlag returns true if the driver is detected to have an OS flag.
+func DriverOSFlag(d Driver) string {
+	for _, opt := range d.GetCreateFlags() {
+		if nameIsOS(opt.String()) {
+			return opt.String()
+		}
+	}
+
+	return ""
+}
+
 // nameIsUserData returns true if the given flag is a userdata flag
 func nameIsUserData(name string) bool {
 	return strings.Contains(name, "user-data") ||
 		strings.Contains(name, "userdata") ||
 		strings.Contains(name, "custom-data") ||
 		strings.Contains(name, "cloud-config")
+}
+
+// nameIsOS returns true if the given flag is an OS flag
+func nameIsOS(name string) bool {
+	return strings.HasSuffix(name, "-os")
 }

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -53,6 +53,7 @@ type Options struct {
 	Memory              int
 	Disk                int
 	CustomInstallScript string
+	MachineOS           string
 	EngineOptions       *engine.Options
 	SwarmOptions        *swarm.Options
 	AuthOptions         *auth.Options

--- a/libmachine/provision/fedora_coreos.go
+++ b/libmachine/provision/fedora_coreos.go
@@ -135,4 +135,3 @@ func (provisioner *FedoraCoreOSProvisioner) Provision(swarmOptions swarm.Options
 	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
 	return err
 }
-


### PR DESCRIPTION
The new `--vmwarevsphere-os` flag and it's value is only passed through when a driver has added support for it. The only driver that currently has support is the vmwarevsphere node driver.

The design behind this flag is that it's value should be set by Rancher and passed through to machine where it should only be consumed and not modified.

In the vsphere driver itself, there is now separate logic for linux and windows when it comes to correctly configuring cloud-init (the custom install script is `.sh` for linux and `.ps1` for windows) and also when adding users/groups via cloud-config (windows uses cloudbase-init which has a slightly different config structure/requirement).

linked issues:
https://github.com/rancher/windows/issues/18


