### PR TITLE
Added Rocky Linux 8

### DIFF
--- a/libmachine/provision/rockylinux.go
+++ b/libmachine/provision/rockylinux.go
@@ -1,0 +1,25 @@
+package provision
+
+import (
+	"github.com/rancher/machine/libmachine/drivers"
+)
+
+func init() {
+	Register("Rocky", &RegisteredProvisioner{
+		New: NewRockyProvisioner,
+	})
+}
+
+func NewRockyProvisioner(d drivers.Driver) Provisioner {
+	return &RockyProvisioner{
+		NewRedHatProvisioner("rocky", d),
+	}
+}
+
+type RockyProvisioner struct {
+	*RedHatProvisioner
+}
+
+func (provisioner *RockyProvisioner) String() string {
+	return "rocky"
+}


### PR DESCRIPTION
Hello,

I added a new provisioner in the `libmachine` module so Rocky Linux 8 is supported by rancher-machine.

Here are the results of the tests that i've done on my side : 

Running `rancher-machine create` :
```
./rancher-machine create -d vmwarevsphere \
--vmwarevsphere-username XXXXXX \
--vmwarevsphere-password XXXXXX \
--vmwarevsphere-memory-size 4096 \
--vmwarevsphere-vcenter XXXXXX \
--vmwarevsphere-vcenter-port 443 \
--vmwarevsphere-disk-size 20000 \
--vmwarevsphere-clone-from "/XXXXXX/vm/Rancher/template/TEMPLATE_ROCKY8" \
--vmwarevsphere-cpu-count "4" \
--engine-install-url https://raw.githubusercontent.com/lukry59/install-docker/master/dist/20.10.12.sh \
--vmwarevsphere-datastore-cluster "/XXXXXX/datastore/Storage Class Gold (SSD)" \
--vmwarevsphere-creation-type "template" \
--vmwarevsphere-datacenter XXXXXX \
--vmwarevsphere-pool "/XXXXXX/host/XXXXXX/Resources" \
--vmwarevsphere-network XXXXXX \
test-rocky8
```

Output from `rancher-machine create`: 
```
Running pre-create checks...
(test-rocky8) Connecting to vSphere for pre-create checks...
Creating machine...
(test-rocky8) Generating SSH Keypair...
(test-rocky8) Cloning VM from VM or Template: /XXXXXX vm/Rancher/template/TEMPLATE_ROCKY8...
(test-rocky8) Finding datastore cluster /XXXXXX/datastore/Storage Class Gold (SSD)
(test-rocky8) Adding network: XXXXXX 
(test-rocky8) Resizing disk disk-1000-0 up from 8388608Kb to 20480000Kb
(test-rocky8) Creating cloud-init.iso
(test-rocky8) Uploading cloud-init.iso
(test-rocky8) Mounting cloudinit user-data.iso
(test-rocky8) Waiting for VMware Tools to come online...
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with rocky...
Installing Docker
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
Checking connection to Docker...
Docker is up and running!
To see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: ./rancher-machine env test-rocky8
(test-rocky8) Closing plugin on server side
```

Output `rancher-machine env test-rocky8` command : 
```
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://XX.XX.XX.XXX:2376"
export DOCKER_CERT_PATH="/root/.docker/machine/machines/test-rocky8"
export DOCKER_MACHINE_NAME="test-rocky8"
```

SSH into `test-rocky8` using `rancher-machine ssh`, output of `docker ps` and `docker info` commands : 
```
[docker@test-rocky8 ~]$ sudo docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
[docker@test-rocky8 ~]$ sudo docker info
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  app: Docker App (Docker Inc., v0.9.1-beta3)
  buildx: Docker Buildx (Docker Inc., v0.7.1-docker)
  scan: Docker Scan (Docker Inc., v0.12.0)

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 0
 Server Version: 20.10.12
 Storage Driver: overlay2
  Backing Filesystem: xfs
  Supports d_type: true
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 7b11cfaabd73bb80907dd23182b9347b4245eb5d
 runc version: v1.0.2-0-g52b36a2
 init version: de40ad0
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 4.18.0-305.25.1.el8_4.x86_64
 Operating System: Rocky Linux 8.4 (Green Obsidian)
 OSType: linux
 Architecture: x86_64
 CPUs: 4
 Total Memory: 3.623GiB
 Name: test-rocky8
 ID: 3XC4:TMEM:CSDG:NDXZ:5TEY:2SY3:422M:TGLE:W6GF:ILTC:5WPD:2J3O
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
  provider=vmwarevsphere
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```

The installation of docker was done with the script `20.10.12.sh` of the PR [rancher/install-docker/#90](https://github.com/rancher/install-docker/pull/90).

Regards,
G