### PR TITLE
Added ad-hoc git clone step for s390x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -146,7 +146,18 @@ platform:
 node:
   arch: s390x
 
+clone:
+  disable: true
+
 steps:
+  - name: clone
+    pull: if-not-exists
+    image: alpine/git:v2.30.2-s390x
+    commands:
+      - git clone $DRONE_GIT_HTTP_URL  .
+      - git fetch origin $DRONE_COMMIT_REF
+      - git checkout $DRONE_COMMIT -b origin/$DRONE_TARGET_BRANCH
+
   - name: build
     pull: default
     image: rancher/dapper:v0.5.8


### PR DESCRIPTION
Added a ad-hoc git clone step for s390x step in order to solve the issue with git clone step. Which has been reported by @rosskirkpat after facing it running the following pipeline https://drone-pr.rancher.io/rancher/machine/319/3/1 

This issue also happened on [racher/rancher 
](https://github.com/rancher/rancher) and applied the fix https://github.com/rancher/rancher/blob/04f609f82de0e9c7dd4d01cede088de467c62d94/.drone.yml#L568

