### PR TITLE
Allow machine to trust Rancher certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 TARGETS := $(shell ls scripts)
 
 .dapper:
-	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
-	@@chmod +x .dapper.tmp
-	@./.dapper.tmp -v
-	@mv .dapper.tmp .dapper
+	@if [[ `uname -s` = "Darwin" && `uname -m` = "arm64" ]]; then\
+		echo "Dapper download is not supported on ARM Macs, you need to build it and add it as .dapper in this directory";\
+		exit 0;\
+	fi;\
+	echo Downloading dapper;\
+	curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp;\
+	chmod +x .dapper.tmp;\
+	./.dapper.tmp -v;\
+	mv .dapper.tmp .dapper;
 
 $(TARGETS): .dapper
 	./.dapper $@

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,24 +1,20 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.suse.com/suse/sle15:15.3
 
-RUN microdnf update -y && \
-    microdnf install unzip file tar gzip openssh-clients && \
-    rm -rf /var/cache/yum
+ENV SSL_CERT_DIR /etc/rancher/ssl
+
+RUN zypper -n update && \
+    zypper -n install git-core curl ca-certificates unzip xz gzip sed tar && \
+    zypper -n clean -a && \
+    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 
 RUN useradd -u 1000 machine
 
-RUN mkdir -p .docker/machine/machines
+RUN mkdir -p .docker/machine/machines /etc/rancher/ssl /home/machine && \
+    chown -R machine /etc/rancher/ssl && \
+    chown -R machine /home/machine
 
 COPY download_driver.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/download_driver.sh
-
-RUN download_driver.sh "https://github.com/linode/docker-machine-driver-linode/releases/download/v0.1.8/docker-machine-driver-linode_linux-amd64.zip" "b31b6a504c59ee758d2dda83029fe4a85b3f5601e22dfa58700a5e6c8f450dc7"
-RUN download_driver.sh "https://drivers.rancher.cn/node-driver-pinganyun/0.3.0/docker-machine-driver-pinganyunecs-linux.tgz" "f84ccec11c2c1970d76d30150916933efe8ca49fe4c422c8954fc37f71273bb5"
-RUN download_driver.sh "https://github.com/cloud-ca/docker-machine-driver-cloudca/files/2446837/docker-machine-driver-cloudca_v2.0.0_linux-amd64.zip" "1757e2b807b0fea4a38eade4e961bcc609853986a44a99a4e86a37ccea1f7679"
-RUN download_driver.sh "https://github.com/cloudscale-ch/docker-machine-driver-cloudscale/releases/download/v1.2.0/docker-machine-driver-cloudscale_v1.2.0_linux_amd64.tar.gz" "e33fbd6c2f87b1c470bcb653cc8aa50baf914a9d641a2f18f86a07c398cfb544"
-RUN download_driver.sh "https://github.com/rancher-plugins/rancher-machine-driver-oci/releases/download/v1.0.1/docker-machine-driver-oci-linux" "6867f59e9f33bdbce34b5bf9476c48d2edc2ef4bca8a2ef82ccaa1de57af811c"
-RUN download_driver.sh "https://github.com/rancher-plugins/docker-machine-driver-otc/releases/download/v2019.5.7/docker-machine-driver-otc" "a2cc921a64e6192d8036afdf07f13f0c8459fc4932d1cfb183efccfac7baea04"
-RUN download_driver.sh "https://github.com/packethost/docker-machine-driver-packet/releases/download/v0.2.2/docker-machine-driver-packet_linux-amd64.zip" "e03c6bc9406c811e03e9bc2c39f43e6cc8c02d1615bd0e0b8ee1b38be6fe201c"
-RUN download_driver.sh "https://github.com/phoenixnap/docker-machine-driver-pnap/releases/download/v0.1.0/docker-machine-driver-pnap_0.1.0_linux_amd64.zip" "5f25a7fbcaca0710b7290216464ca8433fa3d683b59d5e4e674bef2d0a3ff6c7"
 
 COPY rancher-machine entrypoint.sh /usr/local/bin/
 RUN chmod 0777 /usr/local/bin

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -2,6 +2,12 @@
 set -e
 termination_log="/dev/termination-log"
 
+if [ -x "$(command -v c_rehash)" ]; then
+  # c_rehash is run here instead of update-ca-certificates because the latter requires root privileges
+  # and the rancher-machine container is run as non-root user.
+  c_rehash
+fi
+
 for i; do
   shift
   case $i in


### PR DESCRIPTION
The machine pod was not able to trust the Rancher certificates passed to the job
for downloading the drivers. This change will run c_rehash when the machine pod
starts up to allow the curl commands to work.

In addition to using the c_rehash command, the base image is changed to SLE BCI to
be consistent with Rancher.

Issue:
https://github.com/rancher/rancher/issues/36488