### PR TITLE
use mkisofs to create joliet and rockridge isos

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -559,7 +559,7 @@ func commonCloudConfig(machineName, machineOS, encodedData, command, path string
 		"encoding":    "gzip+b64",
 		"content":     fmt.Sprintf("%s", encodedData),
 		"permissions": "0644",
-		"path":        command,
+		"path":        path,
 	}
 	if err := addToCloudConfig(cf, "write_files", writeFile); err != nil {
 		return err

--- a/drivers/vmwarevsphere/cloudinit.go
+++ b/drivers/vmwarevsphere/cloudinit.go
@@ -154,15 +154,40 @@ func (d *Driver) createCloudInitIso() error {
 		return err
 	}
 
-	md := []byte(fmt.Sprintf("local-hostname: %s\n", d.MachineName))
+	md := []byte(fmt.Sprintf("hostname: %s\n", d.MachineName))
 	if err = ioutil.WriteFile(metadata, md, perm); err != nil {
 		return err
 	}
 
-	//making iso
+	// validate that our files are present in the isoDir before creating the ISO
+	for filename, filepath := range map[string]string{"user-data": userdata, "meta-data": metadata} {
+		_, err = os.Stat(filepath)
+		if err != nil {
+			return fmt.Errorf("error: %s found when verifying that %s file was present for machine %s", err, filename, d.MachineName)
+		}
+	}
+
+	err = os.Chdir(isoDir)
+	if err != nil {
+		return err
+	}
+
 	diskImg := filepath.Join(isoDir, isoName)
-	iso := exec.Command("mkisofs", fmt.Sprintf("-o %s", diskImg), "-J", "-R", "-hfs", "-V cidata", "--quiet", fmt.Sprintf("%s,%s", userdata, metadata))
-	return iso.Run()
+	// making iso
+	// iso-level 1 ensures that files may only consist of one section and filenames are restricted to 8.3 characters.
+	// this maintains backwards compatibility with the previous go-diskfs method of creating ISOs
+	isoArgs := []string{"-J", "-r", "-hfs", "-iso-level", "1", "-V", "cidata", "-output", fmt.Sprintf("%s", diskImg), "-graft-points", fmt.Sprintf("%s", dataDir)}
+	iso := exec.Command("mkisofs", isoArgs...)
+	log.Debugf("preparing to run mkisofs command with args: \n%s\n", iso.Args)
+	// while iso.Run() would be simpler, debugging issues is extremely difficult as the machine pod cannot be exec'd into
+	// and the machine container only allows the rancher-machine binary if attempting manual debugging
+	stdoutStderr, err := iso.CombinedOutput()
+	if !iso.ProcessState.Success() || err != nil {
+		log.Errorf("mkisofs process failed, combined stdout/stderr: \n%s\n", stdoutStderr)
+		log.Errorf("error: mkisofs command finished with exit code: %v", iso.ProcessState.ExitCode())
+		return fmt.Errorf("mkisofs command finished with error: %v", err)
+	}
+	return nil
 }
 
 func (d *Driver) mountCloudInitIso(vm *object.VirtualMachine, dc *object.Datacenter, dss *object.Datastore) error {

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -297,7 +297,7 @@ func (f *FileAttrFlag) Attr() types.BaseGuestFileAttributes {
 }
 
 func (d *Driver) SetMachineOSFromFlags(flags drivers.DriverOptions) error {
-	d.OS = strings.ToLower(flags.String("--vmwarevsphere-os"))
+	d.OS = strings.ToLower(flags.String("vmwarevsphere-os"))
 	if d.OS == "" {
 		d.OS = defaultMachineOS
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -13,32 +13,18 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.14
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/to v0.3.0
-	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/aws/aws-sdk-go v1.33.14
-	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bugsnag/bugsnag-go v2.1.2+incompatible
-	github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b // indirect
-	github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f // indirect
-	github.com/cenkalti/backoff v0.0.0-20141124221459-9831e1e25c87 // indirect
 	github.com/digitalocean/godo v0.0.0-20170317202744-d59ed2fe842b
-	github.com/diskfs/go-diskfs v0.0.0-20191115120903-6cf046d472d7
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/exoscale/egoscale v0.12.3
-	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
-	github.com/gofrs/uuid v4.2.0+incompatible // indirect
-	github.com/google/go-querystring v0.0.0-20140804062624-30f7a39f4a21 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gophercloud/gophercloud v0.7.0
 	github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d
-	github.com/gorilla/mux v1.7.3 // indirect
-	github.com/imdario/mergo v0.3.11 // indirect
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/rackspace/gophercloud v0.0.0-20150408191457-ce0f487f6747
 	github.com/rancher/wrangler v0.8.1-0.20210506052526-673b7f8692d9
 	github.com/samalba/dockerclient v0.0.0-20151231000007-f661dd4754aa
 	github.com/skarademir/naturalsort v0.0.0-20150715044055-69a5d87bef62
 	github.com/stretchr/testify v1.6.1
-	github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9 // indirect
 	github.com/urfave/cli v1.20.0
 	github.com/vmware/govcloudair v0.0.2
 	github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0
@@ -51,6 +37,69 @@ require (
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.3.1 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/bitly/go-simplejson v0.5.0 // indirect
+	github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b // indirect
+	github.com/bugsnag/panicwrap v0.0.0-20160118154447-aceac81c6e2f // indirect
+	github.com/cenkalti/backoff v0.0.0-20141124221459-9831e1e25c87 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gofrs/uuid v4.2.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/go-querystring v0.0.0-20140804062624-30f7a39f4a21 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/jmespath/go-jmespath v0.3.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rancher/lasso v0.0.0-20210408231703-9ddd9378d08d // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.27.1 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,6 @@ github.com/digitalocean/godo v0.0.0-20170317202744-d59ed2fe842b h1:HFRlrPXL8yZq8
 github.com/digitalocean/godo v0.0.0-20170317202744-d59ed2fe842b/go.mod h1:h6faOIcZ8lWIwNQ+DN7b3CgX4Kwby5T+nbpNqkUIozU=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
-github.com/diskfs/go-diskfs v0.0.0-20191115120903-6cf046d472d7 h1:R0Q5Sb1rWQwYHrf1etayhN446LSm7gvG2sgE88ochbA=
-github.com/diskfs/go-diskfs v0.0.0-20191115120903-6cf046d472d7/go.mod h1:x7shCYRoIc+XvebaZAnK9x6wsYAS+ExHUjuoZcnO+nc=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
@@ -670,7 +668,6 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -825,8 +822,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=
-gopkg.in/djherbis/times.v1 v1.2.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.suse.com/suse/sle15:15.3
 ENV SSL_CERT_DIR /etc/rancher/ssl
 
 RUN zypper -n update && \
-    zypper -n install git-core curl ca-certificates unzip xz gzip sed tar && \
+    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar && \
     zypper -n clean -a && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 


### PR DESCRIPTION
changes:

- add mkisofs to machine image and use it for linux+windows iso creation (adding Joliet support for Windows)
- remove project dependency on godisk-fs
- go mod tidy
- fix bug in how the `vmwarevsphere-os` flag is validated during machine creation

fix for 

https://github.com/rancher/windows/issues/155
https://github.com/cloudbase/cloudbase-init/issues/89
https://github.com/rancher/rancher/issues/36653

