### PR TITLE
fix mkisofs in a jail, check more nils

### DIFF
--- a/drivers/vmwarevsphere/cloudinit.go
+++ b/drivers/vmwarevsphere/cloudinit.go
@@ -167,9 +167,8 @@ func (d *Driver) createCloudInitIso() error {
 			return fmt.Errorf("error: %s found when verifying that %s file was present for machine %s", err, filename, d.MachineName)
 		}
 	}
-	machineDir := filepath.Join(d.StorePath, "machines", d.MachineName)
 
-	err = os.Chdir(machineDir)
+	err = os.Chdir(filepath.Join(d.StorePath, "machines", d.MachineName))
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func (d *Driver) createCloudInitIso() error {
 	// this maintains backwards compatibility with the previous go-diskfs method of creating ISOs
 	path, err := binaryPathLookup(mkisofsName)
 	if err != nil {
-		return fmt.Errorf("createCloudInitIso: path lookup for %s failed: %s", mkisofsName, err)
+		return fmt.Errorf("createCloudInitIso: path lookup for %s failed: %v", mkisofsName, err)
 	}
 
 	isoArgs := []string{"-J", "-r", "-hfs", "-iso-level", "1", "-V", "cidata", "-output",
@@ -194,12 +193,12 @@ func (d *Driver) createCloudInitIso() error {
 	iso.Stderr = os.Stderr
 	err = iso.Start()
 	if err != nil {
-		return fmt.Errorf("createCloudInitIso: mkisofs command failed to start with error %s", err.Error())
+		return fmt.Errorf("createCloudInitIso: mkisofs command failed to start with error %v", err)
 	}
 	log.Debugf("createCloudInitIso: Waiting for mkisofs command to finish...")
 	err = iso.Wait()
 	if err != nil {
-		return fmt.Errorf("createCloudInitIso: mkisofs command failed to complete with error: %v", err.Error())
+		return fmt.Errorf("createCloudInitIso: mkisofs command failed to complete with error: %v", err)
 	}
 	log.Debugf("createCloudInitIso: mkisofs command successfully finished")
 	return nil
@@ -312,7 +311,7 @@ func (d *Driver) addSSHUserToYaml(sshkey string) (string, error) {
 func binaryPathLookup(name string) (string, error) {
 	path, err := exec.LookPath(name)
 	if err != nil {
-		return "", fmt.Errorf("binaryPathLookup: error returned when trying to find [%s] executable: [%s]", name, err.Error())
+		return "", fmt.Errorf("binaryPathLookup: error returned when trying to find [%s] executable: [%v]", name, err)
 	}
 	return path, nil
 }

--- a/drivers/vmwarevsphere/cloudinit.go
+++ b/drivers/vmwarevsphere/cloudinit.go
@@ -19,7 +19,6 @@ import (
 const (
 	isoName     = "user-data.iso"
 	isoDir      = "cloudinit"
-	mkisofsPath = "/usr/bin/mkisofs"
 	mkisofsName = "mkisofs"
 )
 

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -316,20 +316,23 @@ func (d *Driver) Create() error {
 
 	switch d.CreationType {
 	case "legacy":
-		log.Infof("Creating VM...")
+		log.Infof("creating VM...")
 		b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-		if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
-			return err
+		if b2dutils != nil {
+			if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+				return err
+			}
+			return d.createLegacy()
 		}
-		return d.createLegacy()
+		return fmt.Errorf("unable to perform legacy provisioning of VM %s", d.MachineName)
 	case "library":
-		log.Infof("Creating VM from /%s/%s...", d.ContentLibrary, d.CloneFrom)
+		log.Infof("creating VM from /%s/%s...", d.ContentLibrary, d.CloneFrom)
 		return d.createFromLibraryName()
 	case "vm", "template":
-		log.Infof("Cloning VM from VM or Template: %s...", d.CloneFrom)
+		log.Infof("cloning VM from VM or Template: %s...", d.CloneFrom)
 		return d.createFromVmName()
 	default:
-		log.Infof("Unable to perform any actions, change flags and try again")
+		log.Infof("unable to perform any actions with creationType [%s], change flags and try again", d.CreationType)
 		return nil
 	}
 }

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -316,15 +316,12 @@ func (d *Driver) Create() error {
 
 	switch d.CreationType {
 	case "legacy":
-		log.Infof("creating VM...")
+		log.Infof("creating VM %s", d.MachineName)
 		b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-		if b2dutils != nil {
-			if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
-				return err
-			}
-			return d.createLegacy()
+		if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+			return err
 		}
-		return fmt.Errorf("unable to perform legacy provisioning of VM %s", d.MachineName)
+		return d.createLegacy()
 	case "library":
 		log.Infof("creating VM from /%s/%s...", d.ContentLibrary, d.CloneFrom)
 		return d.createFromLibraryName()


### PR DESCRIPTION
Original panic:

```console
[ERROR] error syncing 'c-lgdkp/m-g2ct4': handler node-controller: Error creating machine: Error in driver during machine creation: Panic in the driver: runtime error: invalid memory address or nil pointer dereference, requeuing
```

This panic was a multi-faceted problem:

- mkisofs not existing in a rancher jail for rke1 vsphere clusters (https://github.com/rancher/rancher/pull/36850)
- mkisofs not being in the proper path for rancher (needs to be `/usr/bin/mkisofs` inside the jail, https://github.com/rancher/rancher/pull/36927)
- mkisofs exec.command needed a path set for it to function inside the jail