### PR TITLE
Use the NO_PROXY environment variable

### DIFF
--- a/libmachine/cert/cert.go
+++ b/libmachine/cert/cert.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/rancher/machine/libmachine/auth"
 	"github.com/rancher/machine/libmachine/log"
-	"github.com/rancher/machine/libmachine/util"
 )
 
 var defaultGenerator = NewX509CertGenerator()
@@ -264,15 +262,7 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 
 	transport := http.Transport{
 		TLSClientConfig: tlsConfig,
-	}
-
-	proxy, err := util.GetProxyURL("https://" + addr)
-	if err != nil {
-		return false, fmt.Errorf("failed to get the https proxy when validating the cert: %v", err)
-	}
-	if proxy != nil {
-		log.Debugf("proxy is used for validating certs: %s", proxy.String())
-		transport.Proxy = http.ProxyURL(proxy)
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	client := http.Client{
 		Transport: &transport,

--- a/libmachine/cert/cert.go
+++ b/libmachine/cert/cert.go
@@ -266,7 +266,7 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 		TLSClientConfig: tlsConfig,
 	}
 
-	proxy, err := util.GetProxyURL(addr, "https")
+	proxy, err := util.GetProxyURL("https://" + addr)
 	if err != nil {
 		return false, fmt.Errorf("failed to get the https proxy when validating the cert: %v", err)
 	}

--- a/libmachine/cert/cert.go
+++ b/libmachine/cert/cert.go
@@ -266,10 +266,13 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 		TLSClientConfig: tlsConfig,
 	}
 
-	envVar := util.GetProxyURL()
-	if envVar != "" {
-		log.Debugf("proxy address is used: %s", envVar)
-		url, err := url.Parse("http://" + envVar)
+	proxy_url, err := util.GetProxyHostnamePortForHost(addr)
+	if err != nil {
+		return false, err
+	}
+	if proxy_url != "" {
+		log.Debugf("proxy address is used: %s", proxy_url)
+		url, err := url.Parse("http://" + proxy_url)
 		if err != nil {
 			return false, err
 		}

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -339,9 +339,14 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 		BinaryPath: sshBinaryPath,
 	}
 	var args []string
-	proxy_url, err := util.GetProxyHostnamePortForHost(host)
+	// http proxy should be used for the SSH connection
+	proxy, err := util.GetProxyURL(host, "http")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get the http proxy for the exernal client: %v", err)
+	}
+	proxy_url := ""
+	if proxy != nil {
+		proxy_url = proxy.Host
 	}
 	ncBinaryPath, _ := exec.LookPath("nc")
 	log.Debugf("proxy_url: %s; ncBinaryPath: %s", proxy_url, ncBinaryPath)

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -338,13 +338,15 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 	client := &ExternalClient{
 		BinaryPath: sshBinaryPath,
 	}
-
 	var args []string
-	envVar := util.GetProxyURL()
+	proxy_url, err := util.GetProxyHostnamePortForHost(host)
+	if err != nil {
+		return nil, err
+	}
 	ncBinaryPath, _ := exec.LookPath("nc")
-	log.Debugf("envVar: %s; ncBinaryPath: %s", envVar, ncBinaryPath)
-	if envVar != "" && ncBinaryPath != "" {
-		args = append(baseSSHArgs, "-o", fmt.Sprintf(SSHProxyArg, ncBinaryPath, envVar), fmt.Sprintf("%s@%s", user, host))
+	log.Debugf("proxy_url: %s; ncBinaryPath: %s", proxy_url, ncBinaryPath)
+	if proxy_url != "" && ncBinaryPath != "" {
+		args = append(baseSSHArgs, "-o", fmt.Sprintf(SSHProxyArg, ncBinaryPath, proxy_url), fmt.Sprintf("%s@%s", user, host))
 	} else {
 		args = append(baseSSHArgs, fmt.Sprintf("%s@%s", user, host))
 	}

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -340,7 +340,7 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 	}
 	var args []string
 	// http proxy should be used for the SSH connection
-	proxy, err := util.GetProxyURL(host, "http")
+	proxy, err := util.GetProxyURL("http://" + host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the http proxy for the exernal client: %v", err)
 	}

--- a/libmachine/util/util.go
+++ b/libmachine/util/util.go
@@ -3,7 +3,11 @@ package util
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
+
+	"github.com/rancher/wrangler/pkg/slice"
 )
 
 func FindEnvAny(names ...string) string {
@@ -15,17 +19,22 @@ func FindEnvAny(names ...string) string {
 	return ""
 }
 
-func GetProxyHostnamePortForHost(hostname string) (string, error) {
-	req, err := http.NewRequest("GET", "http://"+hostname, nil)
+// GetProxyURL returns the URL of the proxy to use for this given hostIP and the scheme,
+// as indicated by the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions thereof).
+// HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.
+func GetProxyURL(hostIp, scheme string) (*url.URL, error) {
+	validSchema := []string{"http", "https"}
+	scheme = strings.ToLower(scheme)
+	if !slice.ContainsString(validSchema, scheme) {
+		return nil, fmt.Errorf("%s is not supported, supported schemes are http and https", scheme)
+	}
+	req, err := http.NewRequest(http.MethodGet, scheme+"://"+hostIp, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	proxy, err := http.ProxyFromEnvironment(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if proxy != nil {
-		return fmt.Sprintf("%s:%s", proxy.Hostname(), proxy.Port()), nil
-	}
-	return "", nil
+	return proxy, nil
 }

--- a/libmachine/util/util.go
+++ b/libmachine/util/util.go
@@ -1,13 +1,9 @@
 package util
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
-
-	"github.com/rancher/wrangler/pkg/slice"
 )
 
 func FindEnvAny(names ...string) string {
@@ -19,16 +15,12 @@ func FindEnvAny(names ...string) string {
 	return ""
 }
 
-// GetProxyURL returns the URL of the proxy to use for this given hostIP and the scheme,
-// as indicated by the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions thereof).
+// GetProxyURL returns the URL of the proxy to use for this given hostUrl as indicated by the environment variables
+// HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions thereof).
 // HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.
-func GetProxyURL(hostIp, scheme string) (*url.URL, error) {
-	validSchema := []string{"http", "https"}
-	scheme = strings.ToLower(scheme)
-	if !slice.ContainsString(validSchema, scheme) {
-		return nil, fmt.Errorf("%s is not supported, supported schemes are http and https", scheme)
-	}
-	req, err := http.NewRequest(http.MethodGet, scheme+"://"+hostIp, nil)
+// The hostUrl may be either a complete URL or a "host[:port]", in which case the "http" scheme is assumed.
+func GetProxyURL(hostUrl string) (*url.URL, error) {
+	req, err := http.NewRequest(http.MethodGet, hostUrl, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37295 

## Problem:
The `rancher-machine` is used to create nodes when we create a node-driver cluster, but it does not use the `NO_PROXY` env variable, so when the proxy cannot talk to the node in the downstream cluster, or the proxy server uses self-signed certs, rancher-machine will not be able to ssh to the node. 

## Solution:
With this fix, rancher-machine will check the NO_PROXY environment variable along with HTTP_PROXY and HTTPS_PROXY to determine if the proxy should be used when it tries to ssh into or validate the certs on the node.

The builtin `ProxyFromEnvironment` function does the check for us:  https://pkg.go.dev/net/http#ProxyFromEnvironment


## Tests:

Prepare the setup:
- run an EC2 instance that has public IP and internet access,  run squid proxy server, the proxy sever uses self-signed certs
- run another EC2 instance in a different subnet, this instance does not have a public IP so no access to the internet
- build the rancher-machine binary from my branch and copy it to the 2nd instance 


### Test 1:
-  set the following env var, notice that the `172.31.0.0/16` is the CIDR of private IP for ec2 instances in this subnet and it is not in the value of  NO_PROXY
```
NO_PROXY=127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,.svc,.cluster.local
HTTPS_PROXY=ec2-54-219-141-33.us-west-1.compute.amazonaws.com:3131
HTTP_PROXY=ec2-54-219-141-33.us-west-1.compute.amazonaws.com:3131
```
- run the following command to create an ec2 instance in the same subnet and have only private IP:
`
./machine/rancher-machine --debug create -d amazonec2 --engine-install-url https://releases.rancher.com/install-docker/20.10.sh --amazonec2-access-key <redacted> --amazonec2-region us-west-1 --amazonec2-tags kubernetes.io/cluster/c-lw8hk,owned --amazonec2-ami ami-0848ae3cb583b8bbe --amazonec2-http-endpoint enabled --amazonec2-http-tokens optional --amazonec2-private-address-only --amazonec2-secret-key <redacted> --amazonec2-instance-type t2.medium --amazonec2-volume-type gp2 --amazonec2-retries 5 --amazonec2-subnet-id subnet-a7342bc0 --amazonec2-zone c --amazonec2-spot-price 0.50 --amazonec2-vpc-id vpc-3d1f335a --amazonec2-block-duration-minutes 0 --amazonec2-root-size 50 --amazonec2-security-group raj-sg --amazonec2-ssh-user ubuntu jiaqi-cmd-3
`

Result: 
see the following message eventually which indicates the ssh connection cannot be established when using the proxy 
```
Using SSH client type: external
proxy_url: ec2-54-219-141-33.us-west-1.compute.amazonaws.com:3131; ncBinaryPath: /usr/bin/nc
Using SSH private key: /home/ubuntu/.docker/machine/machines/jiaqi-cmd-3/id_rsa (-rw-------)
&{[-F /dev/null -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=none -o LogLevel=quiet -o PasswordAuthentication=no -o ServerAliveInterval=60 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand='/usr/bin/nc -X connect -x ec2-54-219-141-33.us-west-1.compute.amazonaws.com:3131 %h %p' ubuntu@172.31.23.246 -o IdentitiesOnly=yes -i /home/ubuntu/.docker/machine/machines/jiaqi-cmd-3/id_rsa -p 22] /usr/bin/ssh <nil>}
About to run SSH command:
exit 0
SSH cmd err, output: exit status 255:
Error getting ssh command 'exit 0' : ssh command error: command: exit 0 err: exit status 255 output:
Error creating machine: Error detecting OS: Too many retries waiting for SSH to be available.  Last error: Maximum number of retries (60) exceeded
notifying bugsnag: [Error creating machine: Error detecting OS: Too many retries waiting for SSH to be available.  Last error: Maximum number of retries (60) exceeded]
bugsnag.Notify: [bugsnag/payload.deliver: Got HTTP 502 Bad Gateway]
```

### Test 2:
- append `172.31.0.0/16` to the value of NO_PROXY:
```
NO_PROXY=127.0.0.0/8,10.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,172.31.0.0/16
```
- run the same `rancher-machine` command 

Result:
- ssh connection is established, the validation for certs is passed
- and rancher-machine exits without errors
The last few lines of the output: 
```
...
Reading CA certificate from /home/ubuntu/.docker/machine/certs/ca.pem
Reading client certificate from /home/ubuntu/.docker/machine/certs/cert.pem
Reading client key from /home/ubuntu/.docker/machine/certs/key.pem
Docker is up and running!
Reticulating splines...
(jiaqi-cmd-4) Calling .GetConfigRaw
[cmdCreateInner] to see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: ./machine/rancher-machine env jiaqi-cmd-4
Making call to close driver server
(jiaqi-cmd-4) Calling .Close
Successfully made call to close driver server
Making call to close connection to plugin binary
Making call to close driver server
(flag-lookup) Calling .Close
(flag-lookup) Closing plugin on server side
Successfully made call to close driver server
Making call to close connection to plugin binary
```