### PR TITLE
Enabling go tests for drivers that ship in Rancher

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -6,4 +6,5 @@ cd $(dirname $0)
 ./clean
 # ./validate
 ./build
+./test
 ./package

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)/..
+
+go test -cover ./drivers/amazonec2/... ./drivers/azure/... ./drivers/digitalocean/... ./drivers/vmwarevsphere/...


### PR DESCRIPTION
Enabled the existing tests for the drivers that we ship in Rancher.

* https://github.com/rancher/windows/issues/143