### PR TITLE
Ensure azure Availability-Sets are cleaned up

### DIFF
--- a/drivers/azure/azureutil/cleanup.go
+++ b/drivers/azure/azureutil/cleanup.go
@@ -151,7 +151,7 @@ func (c *avSetCleanup) LogFields() logutil.Fields { return logutil.Fields{"name"
 
 func (c *avSetCleanup) CanBeDeleted(ctx context.Context, a AzureClient) bool {
 	c.Get(ctx, a) // updates c.ref
-	return c.ref.AvailabilitySetProperties.VirtualMachines == nil && len(*c.ref.AvailabilitySetProperties.VirtualMachines) == 0
+	return c.ref.AvailabilitySetProperties.VirtualMachines == nil || len(*c.ref.AvailabilitySetProperties.VirtualMachines) == 0
 }
 
 type nsgCleanup struct {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/35055

It appears that Azure Availability Sets are not being cleaned up properly when deleting a rancher provisioned instance. All Azure resources are checked to determine if independently created resources are utilizing rancher-managed resources which are queued for deletion. This ensures that other projects utilizing resources created by Rancher are not impacted when cleaning up a Rancher created instance. In the case of Availability Sets, this check was incorrectly written with an `AND` operator as opposed to an `OR` operator. This was causing the conditional to fast-fail, as the `VirtualMachines` slice is never `nil` (but is empty), resulting in machine always thinking that the Availability Set was not safe for deletion. 


Note: This is targeted for 2.7.0, so DNM. 