### PR TITLE
[DNM v2.7.1] Add and implement `--azure-accelerated-networking` flag

### DIFF
--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -311,7 +311,7 @@ func (a AzureClient) CleanupSubnetIfExists(ctx context.Context, resourceGroup, v
 }
 
 // CreateNetworkInterface creates a network interface
-func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location, publicIPAddressID, subnetID, nsgID, privateIPAddress string) error {
+func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location, publicIPAddressID, subnetID, nsgID, privateIPAddress string, acceleratedNetworkingEnabled bool) error {
 	// NOTE(ahmetalpbalkan) This method is expected to fail if the user
 	// specified Azure location is different than location of the virtual
 	// network as Azure does not support cross-region virtual networks. In this
@@ -331,6 +331,7 @@ func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *
 	future, err := networkInterfacesClient.CreateOrUpdate(ctx, resourceGroup, name, network.Interface{
 		Location: to.StringPtr(location),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			EnableAcceleratedNetworking: to.BoolPtr(acceleratedNetworkingEnabled),
 			NetworkSecurityGroup: &network.SecurityGroup{
 				ID: to.StringPtr(nsgID),
 			},


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/37847

### Problem:
Azure offers Accelerated Networking NIC's. These are dedicated hardware units that offer superior performance and off-loads network related processing from the main CPU into a dedicated CPU located within the stand alone NIC. More information can be found [here](https://azure.microsoft.com/fr-fr/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/).

### Solution: 
Add and implement the `--azure-accelerated-networking` flag. When passed this flag will enable the Accelerated Networking feature when creating new network interfaces. This flag will not modify existing network interfaces. 

### Testing: 

Currently UI support is not implemented for this feature. To test this you should manually compile the `rancher-machine` binary and create an Azure VM manually, ensuring you pass the `--azure-accelerated-networking` flag. To check that this feature is enabled after the VM has been created you can do the following 
+ Create an Azure VM and pass the `--azure-accelerated-networking` flag
+ Navigate to the Azure portal 
+ Find the resource group used to create your VM
+ Find the newly created network interface and click it to see its details 
+ In the `Essentials` section look for the `Accelerated Networking` section and ensure it is equal to `Enabled`
![Screen Shot 2022-10-27 at 5 08 55 PM](https://user-images.githubusercontent.com/25062254/198398762-0bcca268-0ff7-4669-94eb-254770d2ef3d.png)

