### PR TITLE
[v2.7.1] Add flags for multiple Azure features

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -36,36 +36,37 @@ const (
 )
 
 const (
-	flAzureEnvironment       = "azure-environment"
-	flAzureSubscriptionID    = "azure-subscription-id"
-	flAzureTenantID          = "azure-tenant-id"
-	flAzureResourceGroup     = "azure-resource-group"
-	flAzureSSHUser           = "azure-ssh-user"
-	flAzureDockerPort        = "azure-docker-port"
-	flAzureLocation          = "azure-location"
-	flAzureSize              = "azure-size"
-	flAzureImage             = "azure-image"
-	flAzureVNet              = "azure-vnet"
-	flAzureSubnet            = "azure-subnet"
-	flAzureSubnetPrefix      = "azure-subnet-prefix"
-	flAzureAvailabilitySet   = "azure-availability-set"
-	flAzureManagedDisks      = "azure-managed-disks"
-	flAzureFaultDomainCount  = "azure-fault-domain-count"
-	flAzureUpdateDomainCount = "azure-update-domain-count"
-	flAzureDiskSize          = "azure-disk-size"
-	flAzurePorts             = "azure-open-port"
-	flAzurePrivateIPAddr     = "azure-private-ip-address"
-	flAzureUsePrivateIP      = "azure-use-private-ip"
-	flAzureStaticPublicIP    = "azure-static-public-ip"
-	flAzureNoPublicIP        = "azure-no-public-ip"
-	flAzureDNSLabel          = "azure-dns"
-	flAzureStorageType       = "azure-storage-type"
-	flAzureCustomData        = "azure-custom-data"
-	flAzureClientID          = "azure-client-id"
-	flAzureClientSecret      = "azure-client-secret"
-	flAzureNSG               = "azure-nsg"
-	flAzurePlan              = "azure-plan"
-	flAzureTags              = "azure-tags"
+	flAzureEnvironment           = "azure-environment"
+	flAzureSubscriptionID        = "azure-subscription-id"
+	flAzureTenantID              = "azure-tenant-id"
+	flAzureResourceGroup         = "azure-resource-group"
+	flAzureSSHUser               = "azure-ssh-user"
+	flAzureDockerPort            = "azure-docker-port"
+	flAzureLocation              = "azure-location"
+	flAzureSize                  = "azure-size"
+	flAzureImage                 = "azure-image"
+	flAzureVNet                  = "azure-vnet"
+	flAzureSubnet                = "azure-subnet"
+	flAzureSubnetPrefix          = "azure-subnet-prefix"
+	flAzureAvailabilitySet       = "azure-availability-set"
+	flAzureManagedDisks          = "azure-managed-disks"
+	flAzureFaultDomainCount      = "azure-fault-domain-count"
+	flAzureUpdateDomainCount     = "azure-update-domain-count"
+	flAzureDiskSize              = "azure-disk-size"
+	flAzurePorts                 = "azure-open-port"
+	flAzurePrivateIPAddr         = "azure-private-ip-address"
+	flAzureUsePrivateIP          = "azure-use-private-ip"
+	flAzureStaticPublicIP        = "azure-static-public-ip"
+	flAzureNoPublicIP            = "azure-no-public-ip"
+	flAzureDNSLabel              = "azure-dns"
+	flAzureStorageType           = "azure-storage-type"
+	flAzureCustomData            = "azure-custom-data"
+	flAzureClientID              = "azure-client-id"
+	flAzureClientSecret          = "azure-client-secret"
+	flAzureNSG                   = "azure-nsg"
+	flAzurePlan                  = "azure-plan"
+	flAzureTags                  = "azure-tags"
+	flAzureAcceleratedNetworking = "azure-accelerated-networking"
 )
 
 const (
@@ -85,22 +86,23 @@ type Driver struct {
 	TenantID       string
 	ResourceGroup  string
 
-	DockerPort      int
-	Location        string
-	Size            string
-	Image           string
-	VirtualNetwork  string
-	SubnetName      string
-	SubnetPrefix    string
-	AvailabilitySet string
-	NSG             string
-	Plan            string
-	ManagedDisks    bool
-	FaultCount      int
-	UpdateCount     int
-	DiskSize        int
-	StorageType     string
-	Tags            map[string]*string
+	DockerPort            int
+	Location              string
+	Size                  string
+	Image                 string
+	VirtualNetwork        string
+	SubnetName            string
+	SubnetPrefix          string
+	AvailabilitySet       string
+	NSG                   string
+	Plan                  string
+	ManagedDisks          bool
+	FaultCount            int
+	UpdateCount           int
+	DiskSize              int
+	StorageType           string
+	Tags                  map[string]*string
+	AcceleratedNetworking bool
 
 	OpenPorts      []string
 	PrivateIPAddr  string
@@ -331,6 +333,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 
 	// Optional flags or Flags of other types
 	d.Tags = azureutil.BuildInstanceTags(fl.String(flAzureTags))
+	d.AcceleratedNetworking = fl.Bool(flAzureAcceleratedNetworking)
 	d.Environment = fl.String(flAzureEnvironment)
 	d.OpenPorts = fl.StringSlice(flAzurePorts)
 	d.PrivateIPAddr = fl.String(flAzurePrivateIPAddr)
@@ -461,7 +464,7 @@ func (d *Driver) Create() error {
 		}
 	}
 	if err := c.CreateNetworkInterface(ctx, d.deploymentCtx, d.ResourceGroup, d.naming().NIC(), d.Location,
-		d.deploymentCtx.PublicIPAddressID, d.deploymentCtx.SubnetID, d.deploymentCtx.NetworkSecurityGroupID, d.PrivateIPAddr); err != nil {
+		d.deploymentCtx.PublicIPAddressID, d.deploymentCtx.SubnetID, d.deploymentCtx.NetworkSecurityGroupID, d.PrivateIPAddr, d.AcceleratedNetworking); err != nil {
 		return err
 	}
 	if !d.ManagedDisks {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -9,15 +9,15 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strconv"
 
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/rancher/machine/drivers/azure/azureutil"
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/rancher/machine/libmachine/log"
 	"github.com/rancher/machine/libmachine/mcnflag"
 	"github.com/rancher/machine/libmachine/state"
-
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 const (
@@ -36,37 +36,39 @@ const (
 )
 
 const (
-	flAzureEnvironment           = "azure-environment"
-	flAzureSubscriptionID        = "azure-subscription-id"
-	flAzureTenantID              = "azure-tenant-id"
-	flAzureResourceGroup         = "azure-resource-group"
-	flAzureSSHUser               = "azure-ssh-user"
-	flAzureDockerPort            = "azure-docker-port"
-	flAzureLocation              = "azure-location"
-	flAzureSize                  = "azure-size"
-	flAzureImage                 = "azure-image"
-	flAzureVNet                  = "azure-vnet"
-	flAzureSubnet                = "azure-subnet"
-	flAzureSubnetPrefix          = "azure-subnet-prefix"
-	flAzureAvailabilitySet       = "azure-availability-set"
-	flAzureManagedDisks          = "azure-managed-disks"
-	flAzureFaultDomainCount      = "azure-fault-domain-count"
-	flAzureUpdateDomainCount     = "azure-update-domain-count"
-	flAzureDiskSize              = "azure-disk-size"
-	flAzurePorts                 = "azure-open-port"
-	flAzurePrivateIPAddr         = "azure-private-ip-address"
-	flAzureUsePrivateIP          = "azure-use-private-ip"
-	flAzureStaticPublicIP        = "azure-static-public-ip"
-	flAzureNoPublicIP            = "azure-no-public-ip"
-	flAzureDNSLabel              = "azure-dns"
-	flAzureStorageType           = "azure-storage-type"
-	flAzureCustomData            = "azure-custom-data"
-	flAzureClientID              = "azure-client-id"
-	flAzureClientSecret          = "azure-client-secret"
-	flAzureNSG                   = "azure-nsg"
-	flAzurePlan                  = "azure-plan"
-	flAzureTags                  = "azure-tags"
-	flAzureAcceleratedNetworking = "azure-accelerated-networking"
+	flAzureEnvironment               = "azure-environment"
+	flAzureSubscriptionID            = "azure-subscription-id"
+	flAzureTenantID                  = "azure-tenant-id"
+	flAzureResourceGroup             = "azure-resource-group"
+	flAzureSSHUser                   = "azure-ssh-user"
+	flAzureDockerPort                = "azure-docker-port"
+	flAzureLocation                  = "azure-location"
+	flAzureSize                      = "azure-size"
+	flAzureImage                     = "azure-image"
+	flAzureVNet                      = "azure-vnet"
+	flAzureSubnet                    = "azure-subnet"
+	flAzureSubnetPrefix              = "azure-subnet-prefix"
+	flAzureAvailabilitySet           = "azure-availability-set"
+	flAzureManagedDisks              = "azure-managed-disks"
+	flAzureFaultDomainCount          = "azure-fault-domain-count"
+	flAzureUpdateDomainCount         = "azure-update-domain-count"
+	flAzureDiskSize                  = "azure-disk-size"
+	flAzurePorts                     = "azure-open-port"
+	flAzurePrivateIPAddr             = "azure-private-ip-address"
+	flAzureUsePrivateIP              = "azure-use-private-ip"
+	flAzureStaticPublicIP            = "azure-static-public-ip"
+	flAzureNoPublicIP                = "azure-no-public-ip"
+	flAzureDNSLabel                  = "azure-dns"
+	flAzureStorageType               = "azure-storage-type"
+	flAzureCustomData                = "azure-custom-data"
+	flAzureClientID                  = "azure-client-id"
+	flAzureClientSecret              = "azure-client-secret"
+	flAzureNSG                       = "azure-nsg"
+	flAzurePlan                      = "azure-plan"
+	flAzureTags                      = "azure-tags"
+	flAzureAcceleratedNetworking     = "azure-accelerated-networking"
+	flAzureEnablePublicIPStandardSKU = "azure-enable-public-ip-standard-sku"
+	flAzureAvailabilityZones         = "azure-availability-zone"
 )
 
 const (
@@ -86,23 +88,25 @@ type Driver struct {
 	TenantID       string
 	ResourceGroup  string
 
-	DockerPort            int
-	Location              string
-	Size                  string
-	Image                 string
-	VirtualNetwork        string
-	SubnetName            string
-	SubnetPrefix          string
-	AvailabilitySet       string
-	NSG                   string
-	Plan                  string
-	ManagedDisks          bool
-	FaultCount            int
-	UpdateCount           int
-	DiskSize              int
-	StorageType           string
-	Tags                  map[string]*string
-	AcceleratedNetworking bool
+	DockerPort                int
+	Location                  string
+	Size                      string
+	Image                     string
+	VirtualNetwork            string
+	SubnetName                string
+	SubnetPrefix              string
+	AvailabilitySet           string
+	NSG                       string
+	Plan                      string
+	ManagedDisks              bool
+	FaultCount                int
+	UpdateCount               int
+	DiskSize                  int
+	StorageType               string
+	Tags                      map[string]*string
+	AcceleratedNetworking     bool
+	AvailabilityZone          string
+	EnablePublicIPStandardSKU bool
 
 	OpenPorts      []string
 	PrivateIPAddr  string
@@ -298,6 +302,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Tags to be applied to the Azure VM instance",
 			EnvVar: "AZURE_TAGS",
 		},
+		mcnflag.StringFlag{
+			Name:   flAzureAvailabilityZones,
+			Usage:  "Specify the Availability Zones the Azure resources should be created in",
+			EnvVar: "AZURE_AVAILABILITY_ZONE",
+		},
+		mcnflag.BoolFlag{
+			Name:   flAzureEnablePublicIPStandardSKU,
+			Usage:  "Specify if a Standard SKU should be used for the Public IP of the Azure VM",
+			EnvVar: "AZURE_STANDARD_PUBLIC_IP_SKU",
+		},
 	}
 }
 
@@ -332,6 +346,8 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	}
 
 	// Optional flags or Flags of other types
+	d.AvailabilityZone = fl.String(flAzureAvailabilityZones)
+	d.EnablePublicIPStandardSKU = fl.Bool(flAzureEnablePublicIPStandardSKU)
 	d.Tags = azureutil.BuildInstanceTags(fl.String(flAzureTags))
 	d.AcceleratedNetworking = fl.Bool(flAzureAcceleratedNetworking)
 	d.Environment = fl.String(flAzureEnvironment)
@@ -370,6 +386,21 @@ func (d *Driver) PreCreateCheck() (err error) {
 	if d.CustomDataFile != "" {
 		if _, err := os.Stat(d.CustomDataFile); os.IsNotExist(err) {
 			return fmt.Errorf("custom-data file %s could not be found", d.CustomDataFile)
+		}
+	}
+
+	if d.AvailabilityZone != "" {
+		if !d.ManagedDisks {
+			return fmt.Errorf("Managed Disks must be used when creating resources in specific Availability Zones (--azure-managed-disks)")
+		}
+		if v, err := strconv.Atoi(d.AvailabilityZone); err != nil || v == 0 {
+			return fmt.Errorf("Each VM can only be assigned to a single Availability Zone. Each zone is denoted by an integer greater than 0")
+		}
+		if !d.EnablePublicIPStandardSKU {
+			return fmt.Errorf("The Standard Public IP SKU must be enabled when creating resources in specific Availablity Zones (--azure-enable-public-ip-standard-sku)")
+		}
+		if d.AvailabilitySet != "" {
+			log.Warn("Both an Availability Set and Availability Zone were specified. Skipping creation of the Availability Set, only creating resources in the specified Availability Zone.")
 		}
 	}
 
@@ -443,8 +474,11 @@ func (d *Driver) Create() error {
 	if err := c.CreateResourceGroup(ctx, d.ResourceGroup, d.Location); err != nil {
 		return err
 	}
-	if err := c.CreateAvailabilitySetIfNotExists(ctx, d.deploymentCtx, d.ResourceGroup, d.AvailabilitySet, d.Location, d.ManagedDisks, int32(d.FaultCount), int32(d.UpdateCount)); err != nil {
-		return err
+	// availability sets and availability zones cannot be used together. The presence of an Availability Zone indicates that an Availability set should not be created / used
+	if d.AvailabilityZone == "" {
+		if err := c.CreateAvailabilitySetIfNotExists(ctx, d.deploymentCtx, d.ResourceGroup, d.AvailabilitySet, d.Location, d.ManagedDisks, int32(d.FaultCount), int32(d.UpdateCount)); err != nil {
+			return err
+		}
 	}
 	if err := c.CreateNetworkSecurityGroup(ctx, d.deploymentCtx, d.ResourceGroup, d.nsgResource, d.Location, d.nsgUsedInPool, d.deploymentCtx.FirewallRules); err != nil {
 		return err
@@ -459,7 +493,7 @@ func (d *Driver) Create() error {
 	if d.NoPublicIP {
 		log.Info("Not creating a public IP address.")
 	} else {
-		if err := c.CreatePublicIPAddress(ctx, d.deploymentCtx, d.ResourceGroup, d.naming().IP(), d.Location, d.StaticPublicIP, d.DNSLabel); err != nil {
+		if err := c.CreatePublicIPAddress(ctx, d.deploymentCtx, d.ResourceGroup, d.naming().IP(), d.Location, d.StaticPublicIP, d.DNSLabel, d.EnablePublicIPStandardSKU); err != nil {
 			return err
 		}
 	}
@@ -478,7 +512,7 @@ func (d *Driver) Create() error {
 	}
 	if err := c.CreateVirtualMachine(ctx, d.ResourceGroup, d.naming().VM(), d.Location, d.Size, d.deploymentCtx.AvailabilitySetID,
 		d.deploymentCtx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.deploymentCtx.SSHPublicKey, d.Image, d.Plan, customData, d.deploymentCtx.StorageAccount,
-		d.ManagedDisks, d.StorageType, int32(d.DiskSize), d.Tags); err != nil {
+		d.ManagedDisks, d.StorageType, int32(d.DiskSize), d.Tags, d.AvailabilityZone); err != nil {
 		return err
 	}
 	ip, err := d.GetIP()
@@ -525,8 +559,11 @@ func (d *Driver) Remove() error {
 	if err := c.DeleteNetworkSecurityGroupIfExists(ctx, d.nsgResource, d.nsgUsedInPool); err != nil {
 		return err
 	}
-	if err := c.CleanupAvailabilitySetIfExists(ctx, d.ResourceGroup, d.AvailabilitySet); err != nil {
-		return err
+	// availability sets and availability zones cannot be used together. The absence of any Availability Zones indicates that an Availability set was created and should be deleted.
+	if d.AvailabilityZone == "" {
+		if err := c.CleanupAvailabilitySetIfExists(ctx, d.ResourceGroup, d.AvailabilitySet); err != nil {
+			return err
+		}
 	}
 	if err := c.CleanupSubnetIfExists(ctx, d.ResourceGroup, d.VirtualNetwork, d.SubnetName); err != nil {
 		return err

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -311,7 +311,7 @@ func (a AzureClient) CleanupSubnetIfExists(ctx context.Context, resourceGroup, v
 }
 
 // CreateNetworkInterface creates a network interface
-func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location, publicIPAddressID, subnetID, nsgID, privateIPAddress string) error {
+func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location, publicIPAddressID, subnetID, nsgID, privateIPAddress string, enabledAcceleratedNetworking bool) error {
 	// NOTE(ahmetalpbalkan) This method is expected to fail if the user
 	// specified Azure location is different than location of the virtual
 	// network as Azure does not support cross-region virtual networks. In this
@@ -331,6 +331,7 @@ func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *
 	future, err := networkInterfacesClient.CreateOrUpdate(ctx, resourceGroup, name, network.Interface{
 		Location: to.StringPtr(location),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			EnableAcceleratedNetworking: to.BoolPtr(enabledAcceleratedNetworking),
 			NetworkSecurityGroup: &network.SecurityGroup{
 				ID: to.StringPtr(nsgID),
 			},

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -160,7 +160,7 @@ func (a AzureClient) DeleteNetworkSecurityGroupIfExists(ctx context.Context, res
 }
 
 // CreatePublicIPAddress creates a public IP address and adds it to our DeploymentContext
-func (a AzureClient) CreatePublicIPAddress(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location string, isStatic bool, dnsLabel string) error {
+func (a AzureClient) CreatePublicIPAddress(ctx context.Context, deploymentCtx *DeploymentContext, resourceGroup, name, location string, isStatic bool, dnsLabel string, enablePublicIPStandardSKU bool) error {
 	log.Info("Creating public IP address.", logutil.Fields{
 		"name":   name,
 		"static": isStatic})
@@ -179,15 +179,19 @@ func (a AzureClient) CreatePublicIPAddress(ctx context.Context, deploymentCtx *D
 		}
 	}
 
+	publicIP := network.PublicIPAddress{
+		Location: to.StringPtr(location),
+		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: ipType,
+			DNSSettings:              dns,
+		},
+	}
+	if enablePublicIPStandardSKU {
+		publicIP.Sku = &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard}
+	}
+
 	publicIPAddressClient := a.publicIPAddressClient()
-	future, err := publicIPAddressClient.CreateOrUpdate(ctx, resourceGroup, name,
-		network.PublicIPAddress{
-			Location: to.StringPtr(location),
-			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				PublicIPAllocationMethod: ipType,
-				DNSSettings:              dns,
-			},
-		})
+	future, err := publicIPAddressClient.CreateOrUpdate(ctx, resourceGroup, name, publicIP)
 	if err != nil {
 		return err
 	}
@@ -560,7 +564,7 @@ func (a AzureClient) removeOSDiskBlob(ctx context.Context, resourceGroup, vmName
 // CreateVirtualMachine creates a VM according to the specifications and adds an SSH key to access the VM
 func (a AzureClient) CreateVirtualMachine(ctx context.Context, resourceGroup, name, location, size, availabilitySetID, networkInterfaceID,
 	username, sshPublicKey, imageName, imagePlan, customData string, storageAccount *storage.AccountProperties, isManaged bool,
-	storageType string, diskSize int32, tags map[string]*string) error {
+	storageType string, diskSize int32, tags map[string]*string, availabilityZone string) error {
 	// TODO: "VM created from Image cannot have blob based disks. All disks have to be managed disks."
 	imgReference, err := a.getImageReference(ctx, imageName, location)
 	if err != nil {
@@ -608,32 +612,43 @@ func (a AzureClient) CreateVirtualMachine(ctx context.Context, resourceGroup, na
 	}
 
 	virtualMachinesClient := a.virtualMachinesClient()
-	future, err := virtualMachinesClient.CreateOrUpdate(ctx, resourceGroup, name,
-		compute.VirtualMachine{
-			Tags:     tags,
-			Location: to.StringPtr(location),
-			VirtualMachineProperties: &compute.VirtualMachineProperties{
-				AvailabilitySet: &compute.SubResource{
-					ID: to.StringPtr(availabilitySetID),
-				},
-				HardwareProfile: &compute.HardwareProfile{
-					VMSize: compute.VirtualMachineSizeTypes(size),
-				},
-				NetworkProfile: &compute.NetworkProfile{
-					NetworkInterfaces: &[]compute.NetworkInterfaceReference{
-						{
-							ID: to.StringPtr(networkInterfaceID),
-						},
+
+	vm := compute.VirtualMachine{
+		Tags:     tags,
+		Location: to.StringPtr(location),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: &compute.HardwareProfile{
+				VMSize: compute.VirtualMachineSizeTypes(size),
+			},
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+					{
+						ID: to.StringPtr(networkInterfaceID),
 					},
 				},
-				OsProfile: osProfile,
-				StorageProfile: &compute.StorageProfile{
-					ImageReference: imgReference,
-					OsDisk:         getOSDisk(name, storageAccount, isManaged, storageType, diskSize),
-				},
 			},
-			Plan: imagePurchasePlan,
-		})
+			OsProfile: osProfile,
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: imgReference,
+				OsDisk:         getOSDisk(name, storageAccount, isManaged, storageType, diskSize),
+			},
+		},
+		Plan: imagePurchasePlan,
+	}
+
+	// The Azure API does not allow you to specify particular Availability Sets
+	// in particular Availability Zones - you can only specify one or the other.
+	// if a user has provided an availability zone it is assumed that
+	// no availability sets should be created / used.
+	if availabilityZone == "" {
+		vm.VirtualMachineProperties.AvailabilitySet = &compute.SubResource{
+			ID: to.StringPtr(availabilitySetID),
+		}
+	} else {
+		vm.Zones = to.StringSlicePtr([]string{availabilityZone})
+	}
+
+	future, err := virtualMachinesClient.CreateOrUpdate(ctx, resourceGroup, name, vm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Issues: https://github.com/rancher/rancher/issues/26955 https://github.com/rancher/rancher/issues/37847  https://github.com/rancher/rancher/issues/39458

This PR adds flags and support within rancher-machine for several Azure features. This includes 
+ adding tags to Azure VM's created by rancher-machine
+ specifying if Azure NIC's should use Accelerated Networking
+ Supporting the specification of Availability Zones when creating VM's. 

This PR is being raised as the individually created PR's raised previously will result in merge conflicts, having them all in a single PR is cleaner. 

#### Here's the testing done for each of the new flags: 

##### Azure Tags
I've manually compiled and run the rancher-machine binary and confirmed that the provided tags are applied to the VM instance.
![Screen Shot 2022-11-01 at 1 58 45 PM](https://user-images.githubusercontent.com/25062254/199304911-3339d44a-f262-4b9a-bf55-4c26919d7814.png)

##### Azure Accelerated Networking 

Currently UI support is not implemented for this feature. To test this you should manually compile the `rancher-machine` binary and create an Azure VM manually, ensuring you pass the `--azure-accelerated-networking` flag. To check that this feature is enabled after the VM has been created you can do the following 
+ Create an Azure VM and pass the `--azure-accelerated-networking` flag
+ Navigate to the Azure portal 
+ Find the resource group used to create your VM
+ Find the newly created network interface and click it to see its details 
+ In the `Essentials` section look for the `Accelerated Networking` section and ensure it is equal to `Enabled`
![Screen Shot 2022-10-27 at 5 08 55 PM](https://user-images.githubusercontent.com/25062254/198398762-0bcca268-0ff7-4669-94eb-254770d2ef3d.png)


##### Azure Availability Zones 
+ I've manually compiled rancher-machine and created a new VM, ensuring that the following flags are passed 
   + `--azure-availability-zone=3`, Azure garuntees that there are at least 3 availability-zones per region. Each VM can only be assigned to a single Availability Zone
   + `--azure-managed-disks`, managed disks must be used when creating VM's in a particular availability zone 
   + `--azure-enable-public-ip-standard-sku`, by default rancher-machine creates public IPs using a basic SKU, a standard SKU must be used if a VM is to be created in a particular Availability Zone 
+ I have observed the command complete successfully when all of the required arguments are passed, and relevant error messages be printed when an incorrect combination of arguments are passed.
+ To confirm the VM has been created in the correct Availability Zone I've navigated to the Azure portal, found the VM, and looked at the `Essentials` description
![Screen Shot 2022-11-01 at 1 56 26 PM](https://user-images.githubusercontent.com/25062254/199304560-b09abddf-b47a-42ab-a346-465ea03752f6.png)

