### PR TITLE
[v2.7] Add missing Accelerated Networking flag to mcnflag set

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -312,6 +312,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Specify if a Standard SKU should be used for the Public IP of the Azure VM",
 			EnvVar: "AZURE_STANDARD_PUBLIC_IP_SKU",
 		},
+		mcnflag.BoolFlag{
+			Name:   flAzureAcceleratedNetworking,
+			Usage:  "Specify if an Accelerated Networking NIC should be created for your VM",
+			EnvVar: "AZURE_ACCELERATED_NETWORKING",
+		},
 	}
 }
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/37847

This issue was found during UI implementation of the Azure accelerated networking feature. 

This PR adds registers the new `azure-accelerated-networking` flag to the `mcnflag` set, which was missed during the prior PR. This is required for the new flag to show up when running `rancher-machine create -d azure --help` as well as for the Rancher schema to be updated properly. Basically, this PR advertises this flag as opposed to simply accepting it. 

## Testing:
Run `rancher-machine create -d azure --help` and confirm the new flag is included in the output

When Rancher machine is bumped in rancher/rancher you should be able to confirm this new flag by visiting 

`https://RANCHER_SERVER/v1/schemas/rke-machine-config.cattle.io.azureconfig`