### PR TITLE
Write debug logs to stderr

### DIFF
--- a/libmachine/log/fmt_machine_logger.go
+++ b/libmachine/log/fmt_machine_logger.go
@@ -38,14 +38,14 @@ func (ml *FmtMachineLogger) SetErrWriter(err io.Writer) {
 func (ml *FmtMachineLogger) Debug(args ...interface{}) {
 	ml.history.Record(args...)
 	if ml.debug {
-		fmt.Fprintln(ml.outWriter, args...)
+		fmt.Fprintln(ml.errWriter, args...)
 	}
 }
 
 func (ml *FmtMachineLogger) Debugf(fmtString string, args ...interface{}) {
 	ml.history.Recordf(fmtString, args...)
 	if ml.debug {
-		fmt.Fprintf(ml.outWriter, fmtString+"\n", args...)
+		fmt.Fprintf(ml.errWriter, fmtString+"\n", args...)
 	}
 }
 


### PR DESCRIPTION
Fix compatibility with gitlab-runner's docker+machine executor. Writing to stdout causes rancher-machine's output to be not parsable.

See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27026#note_474771460

Issue: https://github.com/rancher/rancher/issues/40975