### PR TITLE
Added ability to disable network security groups and availability sets/zone

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -59,6 +59,7 @@ const (
 	flAzureStaticPublicIP            = "azure-static-public-ip"
 	flAzureNoPublicIP                = "azure-no-public-ip"
 	flAzureNoNSG                     = "azure-no-nsg"
+	flAzureNoAvailability            = "azure-no-availability"
 	flAzureDNSLabel                  = "azure-dns"
 	flAzureStorageType               = "azure-storage-type"
 	flAzureCustomData                = "azure-custom-data"
@@ -114,6 +115,7 @@ type Driver struct {
 	UsePrivateIP   bool
 	NoPublicIP     bool
 	NoNSG          bool
+	NoAvailability bool
 	DNSLabel       string
 	StaticPublicIP bool
 	CustomDataFile string // Can provide cloud-config file here
@@ -281,6 +283,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage: "Do not create a network security group for the machine",
 		},
 		mcnflag.BoolFlag{
+			Name:  flAzureNoAvailability,
+			Usage: "Do not create a AvailabilitySet or AvailabilityZone for the machine",
+		},
+		mcnflag.BoolFlag{
 			Name:  flAzureStaticPublicIP,
 			Usage: "Assign a static public IP address to the machine",
 		},
@@ -367,6 +373,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.UsePrivateIP = fl.Bool(flAzureUsePrivateIP)
 	d.NoPublicIP = fl.Bool(flAzureNoPublicIP)
 	d.NoNSG = fl.Bool(flAzureNoNSG)
+	d.NoAvailability = fl.Bool(flAzureNoAvailability)
 	d.StaticPublicIP = fl.Bool(flAzureStaticPublicIP)
 	d.DockerPort = fl.Int(flAzureDockerPort)
 	d.DNSLabel = fl.String(flAzureDNSLabel)
@@ -401,7 +408,7 @@ func (d *Driver) PreCreateCheck() (err error) {
 		}
 	}
 
-	if d.AvailabilityZone != "" {
+	if d.AvailabilityZone != "" && !d.NoAvailability {
 		if !d.ManagedDisks {
 			return fmt.Errorf("Managed Disks must be used when creating resources in specific Availability Zones (--azure-managed-disks)")
 		}
@@ -487,7 +494,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 	// availability sets and availability zones cannot be used together. The presence of an Availability Zone indicates that an Availability set should not be created / used
-	if d.AvailabilityZone == "" {
+	if d.AvailabilityZone == "" && !d.NoAvailability {
 		if err := c.CreateAvailabilitySetIfNotExists(ctx, d.deploymentCtx, d.ResourceGroup, d.AvailabilitySet, d.Location, d.ManagedDisks, int32(d.FaultCount), int32(d.UpdateCount)); err != nil {
 			return err
 		}
@@ -576,7 +583,7 @@ func (d *Driver) Remove() error {
 		return err
 	}
 	// availability sets and availability zones cannot be used together. The absence of any Availability Zones indicates that an Availability set was created and should be deleted.
-	if d.AvailabilityZone == "" {
+	if d.AvailabilityZone == "" && !d.NoAvailability {
 		if err := c.CleanupAvailabilitySetIfExists(ctx, d.ResourceGroup, d.AvailabilitySet); err != nil {
 			return err
 		}

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -643,12 +643,12 @@ func (a AzureClient) CreateVirtualMachine(ctx context.Context, resourceGroup, na
 	// in particular Availability Zones - you can only specify one or the other.
 	// if a user has provided an availability zone it is assumed that
 	// no availability sets should be created / used.
-	if availabilityZone == "" {
+	if availabilityZone != "" {
+		vm.Zones = to.StringSlicePtr([]string{availabilityZone})
+	} else if availabilitySetID != "" {
 		vm.VirtualMachineProperties.AvailabilitySet = &compute.SubResource{
 			ID: to.StringPtr(availabilitySetID),
 		}
-	} else {
-		vm.Zones = to.StringSlicePtr([]string{availabilityZone})
 	}
 
 	future, err := virtualMachinesClient.CreateOrUpdate(ctx, resourceGroup, name, vm)

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -327,6 +327,11 @@ func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *
 		publicIP = &network.PublicIPAddress{ID: to.StringPtr(publicIPAddressID)}
 	}
 
+	var nsg *network.SecurityGroup
+	if nsgID != "" {
+		nsg = &network.SecurityGroup{ID: to.StringPtr(nsgID)}
+	}
+
 	var privateIPAllocMethod = network.Dynamic
 	if privateIPAddress != "" {
 		privateIPAllocMethod = network.Static
@@ -336,9 +341,7 @@ func (a AzureClient) CreateNetworkInterface(ctx context.Context, deploymentCtx *
 		Location: to.StringPtr(location),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 			EnableAcceleratedNetworking: to.BoolPtr(enabledAcceleratedNetworking),
-			NetworkSecurityGroup: &network.SecurityGroup{
-				ID: to.StringPtr(nsgID),
-			},
+			NetworkSecurityGroup:        nsg,
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					Name: to.StringPtr("ip"),


### PR DESCRIPTION
We use rancher-machine in our Gitlab runners to run CI jobs. Network security groups and availability sets/zone are unneeded overhead for our purposes.

This PR adds the ability to disable them.

Also we'd like to see #203 added back (which is how docker-machine originally behaved and was reverted in #208). Having debug logs go to stdout is problematic for our use case. We're currently maintaining a fork with that patch.