### PR TITLE
Fix User-data pass in GCP Machine

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -403,7 +403,7 @@ func (c *ComputeUtil) uploadSSHKeyAndUserdata(instance *raw.Instance, sshKeyPath
 	}
 
 	if userdata != "" {
-		metadata.Items = append(instance.Metadata.Items, &raw.MetadataItems{
+		metadata.Items = append(metadata.Items, &raw.MetadataItems{
 			Key:   "user-data",
 			Value: &userdata,
 		})


### PR DESCRIPTION
Issue: [rancher/rancher#42586](https://github.com/rancher/rancher/issues/42586)

When user data is provided, docker-machine overwrites `metadata.Items` with user-data key, so ssh-keys are not created. This PR fixes the issue. Now, if user data is provided, the key is appended instead of overwriting ssh-keys metadata.

I have tested using the following command 
```
# Using the local build
./bin/rancher-machine create --driver google \
                    --google-project <project-id> \
                    --google-zone us-central1-a \
                    --google-machine-type n1-standard-2 \
                    --google-machine-image ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20230714 \
                    --google-userdata userdata.sh\
                    rancher-vm
```

GCP machine is created successfully with the given userdata.

