### PR TITLE
Use envvar credentials when creating clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 TARGETS := $(shell ls scripts)
 
 .dapper:
-	@if [[ `uname -s` = "Darwin" && `uname -m` = "arm64" ]]; then\
-		echo "Dapper download is not supported on ARM Macs, you need to build it and add it as .dapper in this directory";\
-		exit 0;\
-	fi;\
 	echo Downloading dapper;\
 	curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp;\
 	chmod +x .dapper.tmp;\

--- a/commands/create.go
+++ b/commands/create.go
@@ -328,7 +328,7 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 	// We didn't recognize the driver name.
 	driverName := flagHackLookup("--driver")
 	if driverName == "" {
-		//TODO: Check Environment have to include flagHackLookup function.
+		// TODO: Check Environment have to include flagHackLookup function.
 		driverName = os.Getenv("MACHINE_DRIVER")
 		if driverName == "" {
 			driverName = "virtualbox"
@@ -366,6 +366,7 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 		cmd := &c.Application().Commands[i]
 		if cmd.HasName("create") {
 			cmd = addDriverFlagsToCommand(cliFlags, cmd)
+			break
 		}
 	}
 
@@ -441,7 +442,7 @@ func convertMcnFlagsToCliFlags(mcnFlags []mcnflag.Flag) ([]cli.Flag, error) {
 				EnvVar: f.EnvVar,
 				Usage:  f.Usage,
 
-				//TODO: Is this used with defaults? Can we convert the literal []string to cli.StringSlice properly?
+				// TODO: Is this used with defaults? Can we convert the literal []string to cli.StringSlice properly?
 				Value: &cli.StringSlice{},
 			})
 		default:

--- a/commands/create.go
+++ b/commands/create.go
@@ -366,7 +366,6 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 		cmd := &c.Application().Commands[i]
 		if cmd.HasName("create") {
 			cmd = addDriverFlagsToCommand(cliFlags, cmd)
-			break
 		}
 	}
 

--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -1,9 +1,8 @@
 package commands
 
 import (
-	"testing"
-
 	"flag"
+	"testing"
 
 	"github.com/rancher/machine/commands/commandstest"
 	"github.com/rancher/machine/libmachine/mcnflag"

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -356,6 +356,9 @@ func (d *Driver) buildClient() Ec2Client {
 	config := aws.NewConfig()
 	alogger := AwsLogger()
 
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envAccessKey := os.Getenv("AWS_ACCESS_KEY_ID"); envAccessKey != "" {
 		d.AccessKey = envAccessKey
 	}
@@ -584,7 +587,7 @@ func (d *Driver) checkAMI() error {
 		d.DeviceName = *images.Images[0].RootDeviceName
 	}
 
-	//store bdm list && update size and encryption settings
+	// store bdm list && update size and encryption settings
 	d.bdmList = images.Images[0].BlockDeviceMappings
 
 	return nil

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -11,6 +11,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -354,6 +355,15 @@ func NewDriver(hostName, storePath string) *Driver {
 func (d *Driver) buildClient() Ec2Client {
 	config := aws.NewConfig()
 	alogger := AwsLogger()
+
+	if envAccessKey := os.Getenv("AWS_ACCESS_KEY_ID"); envAccessKey != "" {
+		d.AccessKey = envAccessKey
+	}
+
+	if envSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY"); envSecretKey != "" {
+		d.SecretKey = envSecretKey
+	}
+
 	config = config.WithRegion(d.Region)
 	config = config.WithCredentials(d.awsCredentialsFactory().Credentials())
 	config = config.WithLogger(alogger)

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -39,6 +39,9 @@ func (r requiredOptionError) Error() string {
 // newAzureClient creates an AzureClient helper from the Driver context and
 // initiates authentication if required.
 func (d *Driver) newAzureClient(ctx context.Context) (*azureutil.AzureClient, error) {
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envEnvironment := os.Getenv("AZURE_ENVIRONMENT"); envEnvironment != "" {
 		d.Environment = envEnvironment
 	}

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-12-01/network"
@@ -38,6 +39,22 @@ func (r requiredOptionError) Error() string {
 // newAzureClient creates an AzureClient helper from the Driver context and
 // initiates authentication if required.
 func (d *Driver) newAzureClient(ctx context.Context) (*azureutil.AzureClient, error) {
+	if envEnvironment := os.Getenv("AZURE_ENVIRONMENT"); envEnvironment != "" {
+		d.Environment = envEnvironment
+	}
+
+	if envSubscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID"); envSubscriptionID != "" {
+		d.SubscriptionID = envSubscriptionID
+	}
+
+	if envClientID := os.Getenv("AZURE_CLIENT_ID"); envClientID != "" {
+		d.ClientID = envClientID
+	}
+
+	if envClientSecret := os.Getenv("AZURE_CLIENT_SECRET"); envClientSecret != "" {
+		d.ClientSecret = envClientSecret
+	}
+
 	env, err := azure.EnvironmentFromName(d.Environment)
 	if err != nil {
 		supportedValues := strings.Join(supportedEnvironments, ", ")

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -403,6 +403,10 @@ func (d *Driver) Remove() error {
 }
 
 func (d *Driver) getClient() *godo.Client {
+	if envToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN"); envToken != "" {
+		d.AccessToken = envToken
+	}
+
 	token := &oauth2.Token{AccessToken: d.AccessToken}
 	tokenSource := oauth2.StaticTokenSource(token)
 	client := oauth2.NewClient(oauth2.NoContext, tokenSource)

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -403,6 +403,9 @@ func (d *Driver) Remove() error {
 }
 
 func (d *Driver) getClient() *godo.Client {
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envToken := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN"); envToken != "" {
 		d.AccessToken = envToken
 	}

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -241,6 +241,14 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) client() *egoscale.Client {
+	if envAPIKey := os.Getenv("EXOSCALE_API_KEY"); envAPIKey != "" {
+		d.APIKey = envAPIKey
+	}
+
+	if envSecret := os.Getenv("EXOSCALE_API_SECRET"); envSecret != "" {
+		d.APISecretKey = envSecret
+	}
+
 	return egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
 }
 

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -241,6 +241,9 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) client() *egoscale.Client {
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envAPIKey := os.Getenv("EXOSCALE_API_KEY"); envAPIKey != "" {
 		d.APIKey = envAPIKey
 	}

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -53,6 +54,10 @@ const (
 func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 	ctx := context.Background()
 	var client *http.Client
+
+	if envAuth := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_ENCODED_JSON"); envAuth != "" {
+		driver.Auth = envAuth
+	}
 
 	if driver.Auth != "" {
 		jsonCreds, err := base64.StdEncoding.DecodeString(driver.Auth)

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -55,6 +55,9 @@ func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 	ctx := context.Background()
 	var client *http.Client
 
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envAuth := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_ENCODED_JSON"); envAuth != "" {
 		driver.Auth = envAuth
 	}

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -4,10 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
-
-	"fmt"
 
 	"github.com/rancher/machine/libmachine/log"
 )

--- a/drivers/vmwarevsphere/utils.go
+++ b/drivers/vmwarevsphere/utils.go
@@ -218,6 +218,9 @@ func (d *Driver) generateKeyBundle() error {
 }
 
 func (d *Driver) soapLogin() (*govmomi.Client, error) {
+	// Check if credentials are available via envvars and, if so, use those. This will address cases where credentials
+	// for an existing remote machine are changed in between invocations of Rancher machine. This is done here because
+	// it can't easily be done on driver or CLI initialization due to constrains in this library.
 	if envVCenter := os.Getenv("VSPHERE_VCENTER"); envVCenter != "" {
 		d.IP = envVCenter
 	}

--- a/drivers/vmwarevsphere/utils.go
+++ b/drivers/vmwarevsphere/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/rancher/machine/libmachine/log"
@@ -59,7 +60,7 @@ func (d *Driver) getDatastore(spec *types.VirtualMachineConfigSpec) (*object.Dat
 		return d.finder.Datastore(d.getCtx(), d.Datastore)
 	}
 
-	//nothing set, try default ds cluster then default ds
+	// nothing set, try default ds cluster then default ds
 	log.Infof("Finding default datastore cluster")
 	sp, err := d.finder.DefaultDatastoreCluster(d.getCtx())
 	if err != nil {
@@ -217,6 +218,22 @@ func (d *Driver) generateKeyBundle() error {
 }
 
 func (d *Driver) soapLogin() (*govmomi.Client, error) {
+	if envVCenter := os.Getenv("VSPHERE_VCENTER"); envVCenter != "" {
+		d.IP = envVCenter
+	}
+
+	if envPort, err := strconv.Atoi(os.Getenv("VSPHERE_VCENTER_PORT")); err == nil {
+		d.Port = envPort
+	}
+
+	if envUsername := os.Getenv("VSPHERE_USERNAME"); envUsername != "" {
+		d.Username = envUsername
+	}
+
+	if envPw := os.Getenv("VSPHERE_PASSWORD"); envPw != "" {
+		d.Password = envPw
+	}
+
 	u, err := soap.ParseURL(fmt.Sprintf("https://%s:%d", d.IP, d.Port))
 	if err != nil {
 		return nil, err

--- a/scripts/quick
+++ b/scripts/quick
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+cd $(dirname $0)
+
+./clean
+./build
+./package


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/40608

When Rancher machine runs for the first time, it loads environment variables into memory and uses them to create a machine. Then, it stores this configuration in a secret. Subsequent invocations of the Rancher machine will look for existing config in the secret and use that if it exists. The problem is that, in the time between machine creation and the second invocation, the credentials being used to access the remote machine may have changed. This would cause all invocations of Rancher machine after the first to fail with invalid credentials.

This PR updates machine drivers to try loading credentials from environment variables if they're available before creating machine clients. Unfortunately, because of the way the Docker machine CLI is set up, this can't easily be done elsewhere (like during regular command line flag parsing) without doing a large refactor (which is what I tried initially). Note that, in order to keep the change as small and safe as possible, I've only included envvars that are populated via cloud credential secrets in Rancher.