### PR TITLE
add the support for vmwarevsphere graceful shutdown

### DIFF
--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -1,6 +1,7 @@
 package vmwarevsphere
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -196,6 +197,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "vmwarevsphere-custom-attribute",
 			Usage:  "vSphere custom attribute, format key/value e.g. '200=my custom value'",
 		},
+		mcnflag.IntFlag{
+			EnvVar: "VSPHERE_GRACEFUL_SHUTDOWN_TIMEOUT",
+			Name:   "vmwarevsphere-graceful-shutdown-timeout",
+			Usage:  "how many seconds to wait before timing out when attempting a graceful shutdown for a vSphere virtual machine. A force destroy will perform when the value is zero.",
+		},
 	}
 }
 
@@ -258,6 +264,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		if d.CloneFrom == "" {
 			return fmt.Errorf("creation type clone needs a VM name to clone from, use --vmwarevsphere-clone-from")
 		}
+	}
+
+	d.GracefulShutdownTimeout = flags.Int("vmwarevsphere-graceful-shutdown-timeout")
+	if d.GracefulShutdownTimeout < 0 {
+		return errors.New("vmwarevsphere-graceful-shutdown-timeout can not be negative")
 	}
 
 	return nil

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -200,7 +200,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.IntFlag{
 			EnvVar: "VSPHERE_GRACEFUL_SHUTDOWN_TIMEOUT",
 			Name:   "vmwarevsphere-graceful-shutdown-timeout",
-			Usage:  "how many seconds to wait before timing out when attempting a graceful shutdown for a vSphere virtual machine. A force destroy will perform when the value is zero.",
+			Usage:  "How many seconds to wait before timing out when attempting a graceful shutdown for a vSphere virtual machine. A force destroy will perform when the value is zero.",
 		},
 	}
 }


### PR DESCRIPTION
 https://github.com/rancher/rancher/issues/42308

Please have a look at the internal design doc for details. 

This PR has been tested by compiling and using rancher-machine locally. If we crate a machine with the vmwarevsphere driver and set the `vmwarevsphere-graceful-shutdown-timeout` flag, for example 
```
./rancher-machine create -d vmwarevsphere  .. ... --vmwarevsphere-graceful-shutdown-timeout 100  jiaqi-vsphere-t1
```
Then, when we remove this machine by running `./rancher-machine remove  jiaqi-vsphere-t2`,  we can confirm the feature is working by seeing the following:
- relevant messages in the output 
- In vSphere Center Client, the task "initial guest os shutdow' is triggered, which does not happen if we do not set the flag. 

<img width="1513" alt="graful-shutdown" src="https://github.com/rancher/machine/assets/6218999/17fc8694-dcdf-47c0-bebb-3d460ab26590">

After this PR is merged I am going to cut a new tag and bring it to rancher/rancher