### PR TITLE
drivers/azure/azureutil: fix dropped error

### DIFF
--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -447,7 +447,7 @@ func (a AzureClient) createStorageAccount(ctx context.Context, resourceGroup, lo
 		return nil, err
 	}
 	account, err := future.Result(storageAccountsClient)
-	return account.AccountProperties, nil
+	return account.AccountProperties, err
 }
 
 // VirtualMachineExists sees if a virtual machine exists


### PR DESCRIPTION
This fixes a dropped `err` variable in `drivers/azure/azureutil`.