### PR TITLE
fix: Redhat reboot only required when NM services are disabled.

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -121,7 +121,7 @@ func (provisioner *RedHatProvisioner) disableNetworkManagerSetupService8dot4() e
 	}
 
 	log.Debug("Patching NetworkManager")
-	cmd := "sudo systemctl list-units --all | grep -Fq %s; if [ $? -eq 0 ]; then sudo systemctl disable %s; else echo 0; fi"
+	cmd := "sudo systemctl is-enabled %s; if [ $? -eq 0 ]; then sudo systemctl disable %s && touch /tmp/rancher-machine-reboot; else echo 0; fi"
 	for _, service := range []string{"nm-cloud-setup.timer", "nm-cloud-setup.service"} {
 		if _, err := provisioner.SSHCommand(fmt.Sprintf(cmd, service, service)); err != nil {
 			return err
@@ -129,7 +129,7 @@ func (provisioner *RedHatProvisioner) disableNetworkManagerSetupService8dot4() e
 	}
 
 	// ignore errors here because the SSH connection will close
-	provisioner.SSHCommand("sudo reboot")
+	provisioner.SSHCommand("[ -f /tmp/rancher-machine-reboot ] && rm -f /tmp/rancher-machine-reboot && sudo reboot")
 
 	log.Debug("NetworkManager patched, waiting for machine to reboot...")
 	return drivers.WaitForSSH(provisioner.Driver)


### PR DESCRIPTION

The fix has been released in the tag [v0.15.0-rancher100-patch1](https://github.com/rancher/machine/releases/tag/v0.15.0-rancher100-patch1) and confirmed working by users. 


That makes this PR ready to be merged into the main branch so that the next regular release (tag) of rancher-machine will contain the fix. 

Also,  the plan is to bring the next rancher-machine release to both Rancher v2.7 and v2.8. 



# Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/rancher/issues/43119
https://github.com/rancher/rancher/issues/43778

# Problem

When provisioning a VM that runs RHEL, rancher-machine will disable the `network-manager` service and then reboot the VM. However, the reboot command is now unconditional, which means it still reboots the VM when the `network-manager` service has been disabled by default. This behavior causes problems in certain scenarios.

# Solution

Skip the rebooting step if the `network-manager` service has been disabled by default. 

# Testing

N/A 