### PR TITLE
Fix dropped values during driver unmarshal

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -377,7 +377,9 @@ func (d *Driver) getClient() Ec2Client {
 	return d.clientFactory()
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -381,11 +381,16 @@ func (d *Driver) getClient() Ec2Client {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -326,11 +326,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -322,7 +322,9 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -158,11 +158,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -154,7 +154,9 @@ func (d *Driver) DriverName() string {
 	return "digitalocean"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -187,7 +187,9 @@ func (d *Driver) DriverName() string {
 	return "exoscale"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -191,11 +191,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -201,7 +201,9 @@ func (d *Driver) DriverName() string {
 	return "google"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -205,11 +205,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/noop/driver.go
+++ b/drivers/noop/driver.go
@@ -93,7 +93,9 @@ func (d *Driver) Restart() error {
 	return nil
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -362,7 +362,9 @@ func (d *Driver) DriverName() string {
 	return "openstack"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -366,11 +366,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -127,11 +127,16 @@ func missingEnvOrOption(setting, envVar, opt string) error {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -123,7 +123,9 @@ func missingEnvOrOption(setting, envVar, opt string) error {
 	)
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -224,11 +224,16 @@ func validateClientConfig(c *Client) error {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -220,7 +220,9 @@ func validateClientConfig(c *Client) error {
 	return nil
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -144,7 +144,9 @@ func (d *Driver) DriverName() string {
 	return "vmwarefusion"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -152,7 +152,9 @@ func (d *Driver) DriverName() string {
 	return "vmwarevcloudair"
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -207,7 +207,9 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
-// UnmarshalJSON loads driver config from JSON.
+// UnmarshalJSON loads driver config from JSON. This function is used by the RPCServerDriver that wraps
+// all drivers as a means of populating an already-initialized driver with new configuration.
+// See `RPCServerDriver.SetConfigRaw`.
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -211,11 +211,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.


### PR DESCRIPTION
This PR addresses https://github.com/rancher/rancher/issues/42972, which is caused by the change in https://github.com/rancher/machine/pull/224 that was supposed to address https://github.com/rancher/rancher/issues/40608.

The `UnmarshalJSON` function on the `amazonec2` driver was causing the driver to panic. Here's an explanation in the form of code comments:

**drivers/amazonec2/amazonec2.go**
```go
func (d *Driver) UnmarshalJSON(data []byte) error {
	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
	type targetDriver Driver
	
	// This essentially creates a new `Driver` where all fields have zero values. The problem is
        // that this `amazonec2.Driver` struct type has fields that are functions that are set in
        // `NewDriver`. With this struct initialization, however, those function fields will be nil.
	target := targetDriver{}

        // This unmarshal works fine.
	if err := json.Unmarshal(data, &target); err != nil {
		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
	}

         // This assignment back to `d` from `target` overwrites the non-full function fields in `d`
         // with `nil`. Now, when those functions are called on `d`, a panic will occur.
	*d = Driver(target)
```

The fix was simply to preserve whatever data we already had in `d` by copying it to `target`. I did this for all drivers even though it seems like the `amazonec2` driver is the only one with this problem.

## Testing

Manually tested RKE1 provisioning with the EC2 node driver on Rancher machine built from this branch.
![image](https://github.com/rancher/machine/assets/9647946/07e5f03d-ce80-4c2f-9448-1eaf32020981)
