### PR TITLE
Fix vSphere username rotation / add unit tests for `UnmarshalJSON`

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -66,7 +66,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("AWS_ACCESS_KEY_ID", "test key ID"))
 	os.Args = append(os.Args, []string{"--amazonec2-secret-key", "test key"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure the function fields on the have not been changed to nil and that
 	// config has been pulled in from envvars and args.

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -1,6 +1,7 @@
 package amazonec2
 
 import (
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -55,6 +56,25 @@ var (
 		},
 	}
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	// Create a new driver and make sure its function fields aren't nil.
+	driver := NewDriver("", "")
+	assert.NotNil(t, driver.awsCredentialsFactory)
+	assert.NotNil(t, driver.clientFactory)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("AWS_ACCESS_KEY_ID", "test key ID"))
+	os.Args = append(os.Args, []string{"--amazonec2-secret-key", "test key"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure the function fields on the have not been changed to nil and that
+	// config has been pulled in from envvars and args.
+	assert.NotNil(t, driver.awsCredentialsFactory)
+	assert.NotNil(t, driver.clientFactory)
+	assert.Equal(t, "test key ID", driver.AccessKey)
+	assert.Equal(t, "test key", driver.SecretKey)
+}
 
 func TestConfigureSecurityGroupPermissionsEmpty(t *testing.T) {
 	driver := NewTestDriver()

--- a/drivers/azure/azure_test.go
+++ b/drivers/azure/azure_test.go
@@ -1,0 +1,25 @@
+package azure
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("AZURE_ENVIRONMENT", "test env"))
+	assert.NoError(t, os.Setenv("AZURE_CLIENT_SECRET", "test client secret"))
+	os.Args = append(os.Args, []string{"--azure-subscription-id", "test sub ID", "--azure-client-id", "test client ID"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test env", driver.Environment)
+	assert.Equal(t, "test client secret", driver.ClientSecret)
+	assert.Equal(t, "test client ID", driver.ClientID)
+	assert.Equal(t, "test sub ID", driver.SubscriptionID)
+}

--- a/drivers/azure/azure_test.go
+++ b/drivers/azure/azure_test.go
@@ -15,7 +15,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	assert.NoError(t, os.Setenv("AZURE_ENVIRONMENT", "test env"))
 	assert.NoError(t, os.Setenv("AZURE_CLIENT_SECRET", "test client secret"))
 	os.Args = append(os.Args, []string{"--azure-subscription-id", "test sub ID", "--azure-client-id", "test client ID"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test env", driver.Environment)

--- a/drivers/digitalocean/digitalocean_test.go
+++ b/drivers/digitalocean/digitalocean_test.go
@@ -1,11 +1,24 @@
 package digitalocean
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "")
+
+	// Unmarhsal driver configuration from JSON and args.
+	os.Args = append(os.Args, []string{"--digitalocean-access-token", "test access token"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test access token", driver.AccessToken)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/digitalocean/digitalocean_test.go
+++ b/drivers/digitalocean/digitalocean_test.go
@@ -14,7 +14,10 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	// Unmarhsal driver configuration from JSON and args.
 	os.Args = append(os.Args, []string{"--digitalocean-access-token", "test access token"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test access token", driver.AccessToken)

--- a/drivers/exoscale/exoscale_test.go
+++ b/drivers/exoscale/exoscale_test.go
@@ -1,11 +1,26 @@
 package exoscale
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("EXOSCALE_API_SECRET", "test secret"))
+	os.Args = append(os.Args, []string{"--exoscale-api-key", "test api key"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test secret", driver.APISecretKey)
+	assert.Equal(t, "test api key", driver.APIKey)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/exoscale/exoscale_test.go
+++ b/drivers/exoscale/exoscale_test.go
@@ -15,7 +15,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("EXOSCALE_API_SECRET", "test secret"))
 	os.Args = append(os.Args, []string{"--exoscale-api-key", "test api key"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test secret", driver.APISecretKey)

--- a/drivers/google/google_test.go
+++ b/drivers/google/google_test.go
@@ -14,7 +14,10 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_ENCODED_JSON", "test json"))
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test json", driver.Auth)

--- a/drivers/google/google_test.go
+++ b/drivers/google/google_test.go
@@ -1,11 +1,24 @@
 package google
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "")
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("GOOGLE_APPLICATION_CREDENTIALS_ENCODED_JSON", "test json"))
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test json", driver.Auth)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("", "")

--- a/drivers/openstack/openstack_test.go
+++ b/drivers/openstack/openstack_test.go
@@ -17,7 +17,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	assert.NoError(t, os.Setenv("OS_USER_ID", "test user ID"))
 	os.Args = append(os.Args, []string{"--openstack-username", "test username"}...)
 	os.Args = append(os.Args, []string{"--openstack-password", "test pw"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test auth URL", driver.AuthUrl)

--- a/drivers/openstack/openstack_test.go
+++ b/drivers/openstack/openstack_test.go
@@ -1,11 +1,30 @@
 package openstack
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("OS_AUTH_URL", "test auth URL"))
+	assert.NoError(t, os.Setenv("OS_USER_ID", "test user ID"))
+	os.Args = append(os.Args, []string{"--openstack-username", "test username"}...)
+	os.Args = append(os.Args, []string{"--openstack-password", "test pw"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test auth URL", driver.AuthUrl)
+	assert.Equal(t, "test user ID", driver.UserId)
+	assert.Equal(t, "test username", driver.Username)
+	assert.Equal(t, "test pw", driver.Password)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/rackspace/rackspace_test.go
+++ b/drivers/rackspace/rackspace_test.go
@@ -1,11 +1,26 @@
 package rackspace
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("OS_USERNAME", "test username"))
+	os.Args = append(os.Args, []string{"--rackspace-api-key", "test API key"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test username", driver.Username)
+	assert.Equal(t, "test API key", driver.APIKey)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/rackspace/rackspace_test.go
+++ b/drivers/rackspace/rackspace_test.go
@@ -15,7 +15,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("OS_USERNAME", "test username"))
 	os.Args = append(os.Args, []string{"--rackspace-api-key", "test API key"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test username", driver.Username)

--- a/drivers/softlayer/driver_test.go
+++ b/drivers/softlayer/driver_test.go
@@ -65,7 +65,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	assert.NoError(t, os.Setenv("SOFTLAYER_API_ENDPOINT", "test API endpoint"))
 	os.Args = append(os.Args, []string{"--softlayer-user", "test user"}...)
 	os.Args = append(os.Args, []string{"--softlayer-api-key", "test API key"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test API endpoint", driver.Client.Endpoint)

--- a/drivers/softlayer/driver_test.go
+++ b/drivers/softlayer/driver_test.go
@@ -1,6 +1,7 @@
 package softlayer
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -55,6 +56,21 @@ func getTestDriver() (*Driver, error) {
 	d.SetConfigFromFlags(getDefaultTestDriverFlags())
 	drv := d.(*Driver)
 	return drv, nil
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("SOFTLAYER_API_ENDPOINT", "test API endpoint"))
+	os.Args = append(os.Args, []string{"--softlayer-user", "test user"}...)
+	os.Args = append(os.Args, []string{"--softlayer-api-key", "test API key"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test API endpoint", driver.Client.Endpoint)
+	assert.Equal(t, "test user", driver.Client.User)
+	assert.Equal(t, "test API key", driver.Client.ApiKey)
 }
 
 func TestSetConfigFromFlagsSetsImage(t *testing.T) {

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -150,11 +150,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/vmwarefusion/fusion_darwin_test.go
+++ b/drivers/vmwarefusion/fusion_darwin_test.go
@@ -15,7 +15,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("FUSION_SSH_USER", "test SSH user"))
 	os.Args = append(os.Args, []string{"--vmwarefusion-ssh-password", "test SSH pw"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test SSH user", driver.SSHUser)

--- a/drivers/vmwarefusion/fusion_darwin_test.go
+++ b/drivers/vmwarefusion/fusion_darwin_test.go
@@ -1,11 +1,26 @@
 package vmwarefusion
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("FUSION_SSH_USER", "test SSH user"))
+	os.Args = append(os.Args, []string{"--vmwarefusion-ssh-password", "test SSH pw"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test SSH user", driver.SSHUser)
+	assert.Equal(t, "test SSH pw", driver.SSHPassword)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -158,11 +158,16 @@ func (d *Driver) DriverName() string {
 func (d *Driver) UnmarshalJSON(data []byte) error {
 	// Unmarshal driver config into an aliased type to prevent infinite recursion on UnmarshalJSON.
 	type targetDriver Driver
-	target := targetDriver{}
+
+	// Copy data from `d` to `target` before unmarshalling. This will ensure that already-initialized values
+	// from `d` that are left untouched during unmarshal (like functions) are preserved.
+	target := targetDriver(*d)
+
 	if err := json.Unmarshal(data, &target); err != nil {
 		return fmt.Errorf("error unmarshalling driver config from JSON: %w", err)
 	}
 
+	// Copy unmarshalled data back to `d`.
 	*d = Driver(target)
 
 	// Make sure to reload values that are subject to change from envvars and os.Args.

--- a/drivers/vmwarevcloudair/vcloudlair_test.go
+++ b/drivers/vmwarevcloudair/vcloudlair_test.go
@@ -15,7 +15,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	// Unmarhsal driver configuration from JSON, envvars, and args.
 	assert.NoError(t, os.Setenv("VCLOUDAIR_USERNAME", "test username"))
 	os.Args = append(os.Args, []string{"--vmwarevcloudair-password", "test pw"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test username", driver.UserName)

--- a/drivers/vmwarevcloudair/vcloudlair_test.go
+++ b/drivers/vmwarevcloudair/vcloudlair_test.go
@@ -1,11 +1,26 @@
 package vmwarevcloudair
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("VCLOUDAIR_USERNAME", "test username"))
+	os.Args = append(os.Args, []string{"--vmwarevcloudair-password", "test pw"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test username", driver.UserName)
+	assert.Equal(t, "test pw", driver.UserPassword)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/drivers/vmwarevsphere/flags.go
+++ b/drivers/vmwarevsphere/flags.go
@@ -239,8 +239,8 @@ func (d *Driver) UnmarshalJSON(data []byte) error {
 		d.IP = driverOpts.String("vmwarevsphere-vcenter")
 	}
 
-	if _, ok := driverOpts.Values["vmwarevsphere-user"]; ok {
-		d.Username = driverOpts.String("vmwarevsphere-user")
+	if _, ok := driverOpts.Values["vmwarevsphere-username"]; ok {
+		d.Username = driverOpts.String("vmwarevsphere-username")
 	}
 
 	if _, ok := driverOpts.Values["vmwarevsphere-password"]; ok {

--- a/drivers/vmwarevsphere/vsphere_test.go
+++ b/drivers/vmwarevsphere/vsphere_test.go
@@ -18,7 +18,10 @@ func TestUnmarshalJSON(t *testing.T) {
 	os.Args = append(os.Args, []string{"--vmwarevsphere-vcenter", "test vcenter"}...)
 	os.Args = append(os.Args, []string{"--vmwarevsphere-username", "test user"}...)
 	os.Args = append(os.Args, []string{"--vmwarevsphere-password", "test password"}...)
-	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	driverBytes, err := json.Marshal(driver)
+	assert.NoError(t, err)
+	assert.NoError(t, json.Unmarshal(driverBytes, driver))
 
 	// Make sure that config has been pulled in from envvars and args.
 	assert.Equal(t, "test username", driver.SSHUser)

--- a/drivers/vmwarevsphere/vsphere_test.go
+++ b/drivers/vmwarevsphere/vsphere_test.go
@@ -1,11 +1,32 @@
 package vmwarevsphere
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/rancher/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnmarshalJSON(t *testing.T) {
+	driver := NewDriver("", "").(*Driver)
+
+	// Unmarhsal driver configuration from JSON, envvars, and args.
+	assert.NoError(t, os.Setenv("VSPHERE_SSH_USER", "test username"))
+	assert.NoError(t, os.Setenv("VSPHERE_SSH_PASSWORD", "test pw"))
+	os.Args = append(os.Args, []string{"--vmwarevsphere-vcenter", "test vcenter"}...)
+	os.Args = append(os.Args, []string{"--vmwarevsphere-username", "test user"}...)
+	os.Args = append(os.Args, []string{"--vmwarevsphere-password", "test password"}...)
+	assert.NoError(t, json.Unmarshal([]byte("{}"), driver))
+
+	// Make sure that config has been pulled in from envvars and args.
+	assert.Equal(t, "test username", driver.SSHUser)
+	assert.Equal(t, "test pw", driver.SSHPassword)
+	assert.Equal(t, "test vcenter", driver.IP)
+	assert.Equal(t, "test user", driver.Username)
+	assert.Equal(t, "test password", driver.Password)
+}
 
 func TestSetConfigFromFlags(t *testing.T) {
 	driver := NewDriver("default", "path")

--- a/scripts/test
+++ b/scripts/test
@@ -5,7 +5,7 @@ set -e
 cd $(dirname $0)/..
 
 # Run driver tests.
-go test -cover ./drivers/amazonec2/... ./drivers/azure/... ./drivers/digitalocean/... ./drivers/vmwarevsphere/...
+go test -cover ./drivers/...
 
 # Compile the rancher-machine binary because it is used by the tests in cmd/rancher-machine.
 cd ./cmd/rancher-machine


### PR DESCRIPTION
Follow up from https://github.com/rancher/machine/pull/227 (for https://github.com/rancher/rancher/issues/42972)
- Fix bug where we access the wrong key in vSphere config for the username
- Added unit tests for custom `UnmarshalJSON` implementation on drivers.
- Fixed `UnmarshalJSON` for Fusion and VCloud Air drivers. The bug where turns out to have no effect because all fields in those drivers are marshalled and unmarshalled (i.e. there are no weird function or pointer fields).
- Update CI to run all driver unit tests