### PR TITLE
Remove default bugsnag report

### DIFF
--- a/libmachine/crashreport/crash_report.go
+++ b/libmachine/crashreport/crash_report.go
@@ -1,19 +1,14 @@
 package crashreport
 
 import (
-	"fmt"
-	"os"
-	"runtime"
-
 	"bytes"
-
-	"os/exec"
-
-	"path/filepath"
-
 	"errors"
-
+	"fmt"
 	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/rancher/machine/libmachine/log"
@@ -22,8 +17,8 @@ import (
 )
 
 const (
-	defaultAPIKey  = "a9697f9a010c33ee218a65e5b1f3b0c1"
-	noreportAPIKey = "no-report"
+	defaultDockerMachineAPIKey = "a9697f9a010c33ee218a65e5b1f3b0c1"
+	noreportAPIKey             = "no-report"
 )
 
 type CrashReporter interface {
@@ -51,7 +46,9 @@ type BugsnagCrashReporter struct {
 // NewCrashReporter creates a new bugsnag based CrashReporter. Needs an apiKey.
 var NewCrashReporter = func(baseDir string, apiKey string) CrashReporter {
 	if apiKey == "" {
-		apiKey = defaultAPIKey
+		apiKey = noreportAPIKey
+	} else if apiKey == "docker-machine-default" {
+		apiKey = defaultDockerMachineAPIKey
 	}
 
 	return &BugsnagCrashReporter{


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->[ #40227](https://github.com/rancher/rancher/issues/40227)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The original config of docker-machine used to send errors  to bugsnag, this config was enabled by default both on docker-machine and rancher-machine. 

The user had to express that data sholdn't be sent using: `MACHINE_BUGSNAG_API_TOKEN=no-report` what wasn't intuitive.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

As we do not have have access to those logs the idea was to default the value to not sending logs, with this changes if no ENV is passed no logs will be send to bugsnag. 

It also allows the user to keep the current default behavior by setting: `MACHINE_BUGSNAG_API_TOKEN=docker-machine-default`. 

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

*  Enabled debug mode on machine (envs on rancher) 
*  On rancher went to the create cluster (EC2). 
*  Removed my IAM permission to create EC2 (I had to do this after setting the cluster config)
*  Create Cluster.
*  Check machine logs for "Opting out of crash reporting." Witch means that the logs are not being send to BUGSNAG.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:

    * None -> This just change a default value of a log reporter, I don't think that a test case mus  be done for this.  


  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->



## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Pre-checks won't trigger this, only errors returned by the provider trigger the bugsnag logs.
Example: just changing the Disk size for something like 7 (under AWS limit) will not trigger this. 

I don't think that there is much to test here.   
 
 
### Regressions Considerations
No chance for regressions (IMO) 