### PR TITLE
update default storage driver to overlay2 for suse os

### DIFF
--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -119,7 +119,7 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 			return err
 		}
 	}
-	graphDriver := "overlay"
+	graphDriver := DefaultStorageDriver
 	if strings.Contains(fs, "btrfs") {
 		graphDriver = "btrfs"
 	}


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/43254
overlay storage driver is removed in docker v24.0 [ref](https://docs.docker.com/engine/deprecated/#:~:text=Legacy%20overlay%20storage%20driver&text=The%20overlay%20storage%20driver%20is,0.)