### PR TITLE
Wait for cloud-init to complete before continuing provision

### DIFF
--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -102,6 +102,12 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
+	log.Debug("waiting for cloud-init to complete")
+	err := waitForCloudInit(provisioner)
+	if err != nil {
+		return err
+	}
+
 	storageDriver, err := decideStorageDriver(provisioner, DefaultStorageDriver, engineOptions.StorageDriver)
 	if err != nil {
 		return err

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -270,6 +270,16 @@ func checkDaemonUp(p Provisioner, dockerPort int) func() bool {
 	}
 }
 
+// waitForCloudInit runs `cloud-init status --wait` on the node in order to wait for the node to be ready before
+// continuing execution.
+func waitForCloudInit(p Provisioner) error {
+	_, err := p.SSHCommand("sudo cloud-init status --wait")
+	if err != nil {
+		return fmt.Errorf("failed to wait for cloud-init: %w", err)
+	}
+	return nil
+}
+
 func WaitForDocker(p Provisioner, dockerPort int) error {
 	if err := mcnutils.WaitForSpecific(checkDaemonUp(p, dockerPort), 10, 3*time.Second); err != nil {
 		return NewErrDaemonAvailable(err)


### PR DESCRIPTION
Original Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1215
Actual Issue: https://github.com/rancher/rancher/issues/43586

The problem appears to be that with ubuntu 22.04 there is either a lot more going on at startup or in the cloud-init that installing docker _immediately_ after the ssh daemon is up can cause any subsequent `apt` commands to be flakey. 

Notable failures include:
- `apt-get update` failing to pull down repo lists
- `curl <install-docker.sh> | sh -` failing to install docker with a _very_ helpful `Error installing Docker: ` error message

The fix is just to wait for cloud-init to be completed when starting the machine-provision process.

---

### Tests
I tested this with ubuntu 20.04 and ubuntu 22.04 which were the only supported dpkg distros in the UI for DO. ~This code would technically get executed when the downstream node is debian as well - but since cloud-init is what is used I imagine it'll be ok.~ not anymore - it is only part of the ubuntu+systemd provisioner. 