### PR TITLE
re-add ssh client to rancher-machine container

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.suse.com/bci/bci-base:15.4.27.14.23
 ENV SSL_CERT_DIR /etc/rancher/ssl
 
 RUN zypper -n update && \
-    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar && \
+    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar openssh-clients && \
     zypper -n clean -a && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/45173

rancher images currently being built no longer run due to the missing package openssh-clients. rancher-machine  when running and causes rancher-macine to have issue in some case if it does not exist.
The package is missing since git-core which was being installed by rancher no longer requires openssh-clients.

Root causes of this issue are rancher-machine container does not explicitly install openssh-clients.

This PR fix the issue by specifically installing the ssh client