### PR TITLE
Bump base image to `bci-base:15.5`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.14.23
+FROM registry.suse.com/bci/bci-base:15.5
 
 ENV SSL_CERT_DIR /etc/rancher/ssl
 


### PR DESCRIPTION
Bump the base image to `bci-base:15.5`, which is a more recent version than `bci-base:15.4` and fix some low hanging CVEs in base OS packages.