### PR TITLE
Makefile: fix dapper install on Darwin/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,11 @@
 TARGETS := $(shell ls scripts)
 
 .dapper:
-	@if [[ `uname -s` = "Darwin" && `uname -m` = "arm64" ]]; then\
-		echo "Dapper download is not supported on ARM Macs, you need to build it and add it as .dapper in this directory";\
-		exit 0;\
-	fi;\
-	echo Downloading dapper;\
-	curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp;\
-	chmod +x .dapper.tmp;\
-	./.dapper.tmp -v;\
-	mv .dapper.tmp .dapper;
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper
 	./.dapper $@


### PR DESCRIPTION
Fix install of dapper on Darwin/arm64.

The Makefile block is copied from [dapper's Makefile](https://github.com/rancher/dapper/blob/cefa6aa21b43ee6b0c5a992f5c593563ddac7da0/Makefile#L3).