### PR TITLE
chore: use native arch for dapper ; upgrade Go to 1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}


### PR DESCRIPTION
Upgrade Dockerfile.dapper:
- use the native arch Docker image (ex: amd64 on Apple Silicon) to run the dapper contained build: faster build (`make build CROSS=1`) on Apple Silicon
- upgrade Go to 1.22 as it contains the latest security fixes (targets macOS 10.15+, Windows 10+)

(both changes affect the same line in Dockerfile.dapper)