### PR TITLE
Update SSH retry so it doesn't swallow errors

### DIFF
--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -2,9 +2,9 @@ package drivers
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/rancher/machine/libmachine/log"
-	"github.com/rancher/machine/libmachine/mcnutils"
 	"github.com/rancher/machine/libmachine/ssh"
 )
 
@@ -50,21 +50,20 @@ func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
 	return output, nil
 }
 
-func sshAvailableFunc(d Driver) func() bool {
-	return func() bool {
-		log.Debug("Getting to WaitForSSH function...")
-		if _, err := RunSSHCommandFromDriver(d, "exit 0"); err != nil {
-			log.Debugf("Error getting ssh command 'exit 0' : %s", err)
-			return false
-		}
-		return true
-	}
-}
-
+// WaitForSSH tries to run `exit 0` on the host machine using the driver. It will retry up to
+// 60 times with 3 seconds in between each attempt. If the command still errors after the final
+// attempt, the error will be returned.
 func WaitForSSH(d Driver) error {
-	// Try to dial SSH for 30 seconds before timing out.
-	if err := mcnutils.WaitFor(sshAvailableFunc(d)); err != nil {
-		return fmt.Errorf("Too many retries waiting for SSH to be available.  Last error: %s", err)
+	var lastErr error
+	for i := 0; i < 60; i++ {
+		log.Debug("Getting to WaitForSSH function...")
+		if _, lastErr = RunSSHCommandFromDriver(d, "exit 0"); lastErr == nil {
+			return nil
+		}
+
+		log.Debugf("Error getting SSH command 'exit 0' : %s", lastErr)
+		time.Sleep(3 * time.Second)
 	}
-	return nil
+
+	return fmt.Errorf("Too many retries waiting for SSH to be available. Last error: %w", lastErr)
 }


### PR DESCRIPTION
Just made a small update to the `WaitForSSH` function so it doesn't swallow errors.