### PR TITLE
Change the generated image to `bci-busybox:15.6`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=final / /chroot/
 RUN zypper --non-interactive refresh && \
     zypper --installroot /chroot -n rm busybox-less && \
     zypper --installroot /chroot -n install \
-        git-core curl mkisofs openssh-clients && \
+        git-core curl mkisofs openssh-clients openssl patterns-base-fips && \
     zypper -n clean -a && \
     rm -rf /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -22,7 +22,7 @@ COPY download_driver.sh /chroot/usr/local/bin/
 RUN chmod +x /chroot/usr/local/bin/download_driver.sh
 
 COPY rancher-machine entrypoint.sh /chroot/usr/local/bin/
-RUN chmod 0777 /chroot/usr/local/bin
+RUN chmod 0755 /chroot/usr/local/bin
 
 FROM scratch
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,25 +1,39 @@
-FROM registry.suse.com/bci/bci-base:15.6
+ARG BCI_VERSION=15.6
+
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+# Creates the base dir for the target image, and hydrates it with the
+# final image's contents.
+RUN mkdir /chroot
+COPY --from=final / /chroot/
+
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n rm busybox-less && \
+    zypper --installroot /chroot -n install \
+        git-core curl mkisofs openssh-clients && \
+    zypper -n clean -a && \
+    rm -rf /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+RUN useradd -u 1000 machine
+RUN cp /etc/passwd /chroot/etc/passwd
+
+COPY download_driver.sh /chroot/usr/local/bin/
+RUN chmod +x /chroot/usr/local/bin/download_driver.sh
+
+COPY rancher-machine entrypoint.sh /chroot/usr/local/bin/
+RUN chmod 0777 /chroot/usr/local/bin
+
+FROM scratch
 
 ENV SSL_CERT_DIR /etc/rancher/ssl
 
-RUN zypper -n update && \
-    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar openssh-clients && \
-    zypper -n clean -a && \
-    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
-
-RUN useradd -u 1000 machine
+COPY --from=builder /chroot /
 
 RUN mkdir -p .docker/machine/machines /etc/rancher/ssl /home/machine && \
     chown -R machine /etc/rancher/ssl && \
     chown -R machine /home/machine
 
-COPY download_driver.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/download_driver.sh
-
-COPY rancher-machine entrypoint.sh /usr/local/bin/
-RUN chmod 0777 /usr/local/bin
-
 USER 1000
-WORKDIR /home/machine
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Issues:
* https://github.com/rancher/rancher/issues/46100
* https://github.com/rancher/rancher/issues/47257

The aim of this change is to decrease the long-term number of CVEs this image gets due to the decreased attack surface. As a result, the final image is 100MB lighter and does not contain the following commands:

```
agetty
alternatives
applygnupgdefaults
basenc
blkdiscard
blockdev
cfdisk
chage
chcpu
chfn
chkconfig
chkstat
chmem
choom
chsh
col
colcrt
colrm
column
comps2solv
container-suseconnect
cracklib-unpacker
create-cracklib-dict
ctrlaltdel
delpart
diff3
dir
dircolors
dumpsolv
eject
expiry
faillock
fdformat
filesize
fillup
fincore
fips_standalone_hmac
flushb
fmt
fsfreeze
fstrim
funzip-plain
g13
g13-syshelp
gendiff
get_kernel_version
gpasswd
gpg
gpg2
gpg-agent
gpgconf
gpg-connect-agent
gpgparsemail
gpgscm
gpgsm
gpgsplit
gpgtar
gpgv
gpgv2
gpg-wks-server
gpg-zip
groupadd
groupdel
groupmod
grpck
gzexe
hardlink
hwclock
info
infocmp
installation_sources
installcheck
install-info
ionice
ipcmk
irqtop
isosize
join
kbxutil
lastlog
line
look
lsmem
lsns
lzcmp
lzdiff
lzegrep
lzfgrep
lzgrep
lzless
lzmainfo
lzmore
mcookie
mergesolv
mkfs
mkfs.bfs
mkfs.cramfs
mkfs.minix
mkinfodir
newgrp
newuidmap
openssl
p11-kit
pinentry-tty
pinky
pr
prlimit
rcca-certificates
readprofile
refresh_initrd
rename
repo2solv
repo2solv.sh
repomdxml2solv
resizepart
rfkill
rpm2cpio
rpmconfigcheck
rpmdb
rpmdb2solv
rpmgraph
rpmkeys
rpmlocate
rpmmd2solv
rpmqpack
rpmquery
rpms2solv
rpmsign
rpmspec
rpmverify
rtcwake
runuser
safe-rmdir
scdaemon
scriptlive
sdiff
service
setterm
sfdisk
sg
sha224sum
skill
slabtop
smart_agetty
sshd.hmac
susetags2solv
swaplabel
swapoff
swapon
sysconf_addword
tabs
taskset
tload
toe
tput
trust
tset
tsort
uclampset
ul
uname26
unzip-plain
unzipsfx
unzipsfx-plain
updateinfoxml2solv
useradd.local
userdel
userdel-post.local
userdel-pre.local
usermod
vigr
vipw
vmstat
watchgnupg
whereis
wipefs
x86_64
xzcmp
xzdec
xzdiff
xzegrep
xzfgrep
xzgrep
xzless
xzmore
xznew
yzpper
zcmp
zdiff
zdump
zegrep
zfgrep
zforce
zic
zipgrep
zipgrep-plain
zipinfo
zramctl
zypp-CheckAccessDeleted
zypper
zypp-NameReqPrv
zypp-refresh
```