### PR TITLE
Allow cloud-config to Work on Distros with Read-Only /usr Partitions

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -453,6 +453,10 @@ func writeCloudConfig(machineName, encodedData, machineOS, hostname string, cf m
 	command := "sh"
 	path := "/usr/local/custom_script/install.sh"
 	key := "hostname"
+	// allow the script to work on distros with read-only /usr partitions
+	if strings.Contains(machineOS, "coreos") || strings.Contains(machineOS, "coreos") {
+		path = "/var/run/install.sh"
+	}
 	if strings.Contains(machineOS, "windows") {
 		// the writeFile path should ideally be C:\usr\local\custom_script\install.ps1
 		// however, we can't guarantee that directory exists or can be created on the target machine

--- a/commands/create.go
+++ b/commands/create.go
@@ -451,12 +451,9 @@ func updateUserdataFile(driverOpts *rpcdriver.RPCFlags, machineName, hostname, u
 // on how hostnames are set in cloud-config (userdata)
 func writeCloudConfig(machineName, encodedData, machineOS, hostname string, cf map[interface{}]interface{}, newUserDataFile *os.File) error {
 	command := "sh"
-	path := "/usr/local/custom_script/install.sh"
-	key := "hostname"
 	// allow the script to work on distros with read-only /usr partitions
-	if strings.Contains(machineOS, "coreos") || strings.Contains(machineOS, "coreos") {
-		path = "/var/run/install.sh"
-	}
+	path := "/var/run/install.sh"
+	key := "hostname"
 	if strings.Contains(machineOS, "windows") {
 		// the writeFile path should ideally be C:\usr\local\custom_script\install.ps1
 		// however, we can't guarantee that directory exists or can be created on the target machine


### PR DESCRIPTION
This PR is to allow cloud-config to work on distros with read-only /usr partitions, such as Flatcar. It simply changes the hard-coded path from under the `/usr` tree to under the `/var/run` tree, which is more portable. 

Please note that without this change bootstrapping Flatcar RKE2 nodes in Rancher is not possible.