### PR TITLE
Fix the issue where rancher-machine does not clean up vSphere VMs that are in failed status

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -144,6 +144,13 @@ func (d *Driver) createLegacy() error {
 	if err != nil {
 		return err
 	}
+	log.Info("Fetching MachineID ...")
+	// save the machine id as soon as the VM is created
+	if _, err = d.GetMachineId(); err != nil {
+		// no need to return the error, it is not a blocker for creating the machine,
+		// we will fetch the machineID again after starting the VM
+		log.Warnf("[createLegacy] failed to fetch MachineID for %s: %v", d.MachineName, err)
+	}
 
 	log.Infof("Uploading Boot2docker ISO ...")
 	vm := object.NewVirtualMachine(c.Client, info.Result.(types.ManagedObjectReference))
@@ -274,6 +281,14 @@ func (d *Driver) createFromVmName() error {
 		return err
 	}
 
+	log.Info("Fetching MachineID ...")
+	// save the machine id as soon as the VM is created
+	if _, err = d.GetMachineId(); err != nil {
+		// no need to return the error, it is not a blocker for creating the machine,
+		// we will fetch the machineID again after starting the VM
+		log.Warnf("[createFromVmName] failed to fetch MachineID for %s: %v", d.MachineName, err)
+	}
+
 	// Retrieve the new VM
 	vm := object.NewVirtualMachine(c.Client, info.Result.(types.ManagedObjectReference))
 	if err := d.addNetworks(vm, d.networks); err != nil {
@@ -355,6 +370,14 @@ func (d *Driver) createFromLibraryName() error {
 	obj, err := d.finder.ObjectReference(d.getCtx(), *ref)
 	if err != nil {
 		return err
+	}
+
+	log.Info("Fetching MachineID ...")
+	// save the machine id as soon as the VM is created
+	if _, err = d.GetMachineId(); err != nil {
+		// no need to return the error, it is not a blocker for creating the machine,
+		// we will fetch the machineID again after starting the VM
+		log.Warnf("[createFromLibraryName] failed to fetch MachineID for %s: %v", d.MachineName, err)
 	}
 
 	// At this point, the VM is deployed from content library with defaults from template

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -453,6 +453,7 @@ func (d *Driver) Kill() error {
 func (d *Driver) Remove() error {
 	if d.MachineId == "" {
 		// no guid from config, nothing in vsphere to delete
+		log.Info("MachineID is empty, skipping removing VM")
 		return nil
 	}
 

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -136,10 +136,12 @@ func (api *Client) Create(h *host.Host) error {
 	log.Info("Creating machine...")
 
 	if err := api.performCreate(h); err != nil {
-		// it is possible that the VM is instantiated but fails to bootstrap,
-		// save the machine to the store, so the VM and associated resources can be found and destroyed later
-		if err := api.Save(h); err != nil {
-			log.Warnf("Error saving host to store after creation fails: %s", err)
+		if h.Driver.DriverName() == "vmwarevsphere" {
+			// it is possible that the VM is instantiated but fails to bootstrap,
+			// save the machine to the store, so the VM and associated resources can be found and destroyed later
+			if err := api.Save(h); err != nil {
+				log.Warnf("Error saving host to store after creation fails: %s", err)
+			}
 		}
 		return fmt.Errorf("Error creating machine: %s", err)
 	}

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -136,6 +136,11 @@ func (api *Client) Create(h *host.Host) error {
 	log.Info("Creating machine...")
 
 	if err := api.performCreate(h); err != nil {
+		// it is possible that the VM is instantiated but fails to bootstrap,
+		// save the machine to the store, so the VM and associated resources can be found and destroyed later
+		if err := api.Save(h); err != nil {
+			log.Warnf("Error saving host to store after creation fails: %s", err)
+		}
 		return fmt.Errorf("Error creating machine: %s", err)
 	}
 


### PR DESCRIPTION
**Issue**

https://github.com/rancher/rancher/issues/44212 
Possibly: https://github.com/rancher/rancher/issues/46340

**Problem**
 
In general, rancher-machine takes at least three steps to provision a vSphere machine: first, create the VM instance; then customize the VM's configuration; and finally bootstrap the VM.
Previously, rancher-machine saves the VM's ID only after the bootstrapping step succeeds. If rancher-machine creates but fails to start the VM, it will not destroy the VM because the VM's uuid is missing.

**Solution**

Now, rancher-machine retrieves and saves the uuid as machineID as soon as the VM is created, and saves the updated Host object to the store even if the creation process fails. This ensures the machineID is always preserved so that rancher-machine can find and destroy the VM on the vSphere server side properly.
 

**Validation**

Steps:
- build rancher-machine for Linux amd64 from this branch 
- run Rancher v2.8.5 in docker-install mode 
- replace the rancher-machine binary in the container by using the `docker scp` command 
- create vSphere node template with four different creation methods: `Deploy from template: Data Center`, `Deploy from template: Content Library`, `Clone an existing virtual machine`, and `Install from boot2docker ISO(Legacy)` 
- on the node template set the CPUs to 36 to ensure the VM can NOT be assigned to any vSpherer server 
- provision RKE1 vSphere node-driver clusters with those 4 node templates
- provision RKE2 vSphere node-driver clusters with those 4 node templates

Results:

During the cluster provisioning process, Rancher keeps creating new nodes and removing old ones from the DS clusters, meanwhile creating new VMs and removing old ones on the vSphere server. 

We also see the following messages in Rancher logs:
```
2024/07/23 15:33:37 [INFO] [node-controller] Removing node jiaqi-a5
2024/07/23 15:33:37 [INFO] [node-controller] About to remove jiaqi-a5
2024/07/23 15:33:38 [INFO] [node-controller] (jiaqi-a5) Using datacenter /Datacenter
2024/07/23 15:33:39 [INFO] [node-controller] (jiaqi-a5) Using network /Datacenter/network/VM Network
2024/07/23 15:33:44 [INFO] [node-controller] (jiaqi-a5) Using hostsystem /Datacenter/host/Cluster/xx.xx.xx.xx
2024/07/23 15:33:44 [INFO] [node-controller] (jiaqi-a5) Using ResourcePool /Datacenter/host/Cluster/Resources/jiaqi-resource-pool
2024/07/23 15:33:48 [INFO] [node-controller] (jiaqi-a5) Removing user-data.iso
2024/07/23 15:33:49 [INFO] [node-controller] (jiaqi-a5) Destroying VM jiaqi-a5 (ID: 42183429-a34e-3fce-7857-a912af50c0af)
2024/07/23 15:33:51 [INFO] [node-controller] Successfully removed jiaqi-a5
2024/07/23 15:33:51 [INFO] [node-controller] (jiaqi-a5) Closing plugin on server side
2024/07/23 15:33:51 [INFO] [node-controller] (jiaqi-a5) Closing plugin on server side
2024/07/23 15:33:51 [INFO] [node-controller] Removing node jiaqi-a5 done
2024/07/23 15:33:51 [DEBUG] Cleaning up [management-state/node/nodes/jiaqi-a5]
```