### PR TITLE
Bump Go versions to 1.22 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/machine
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.5
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/46517
https://github.com/rancher/rancher/issues/46516
https://github.com/rancher/rancher/issues/46515

Changes:
- bump golang toolchain to go1.22.5
- bump base image to bci/golang:1.22 for Dapper 