### PR TITLE
[47853] Downloading node drivers no longer works

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,39 +1,25 @@
-ARG BCI_VERSION=15.6
-
-FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
-FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
-
-# Creates the base dir for the target image, and hydrates it with the
-# final image's contents.
-RUN mkdir /chroot
-COPY --from=final / /chroot/
-
-RUN zypper --non-interactive refresh && \
-    zypper --installroot /chroot -n rm busybox-less && \
-    zypper --installroot /chroot -n install \
-        git-core curl mkisofs openssh-clients openssl patterns-base-fips && \
-    zypper -n clean -a && \
-    rm -rf /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
-
-RUN useradd -u 1000 machine
-RUN cp /etc/passwd /chroot/etc/passwd
-
-COPY download_driver.sh /chroot/usr/local/bin/
-RUN chmod +x /chroot/usr/local/bin/download_driver.sh
-
-COPY rancher-machine entrypoint.sh /chroot/usr/local/bin/
-RUN chmod 0755 /chroot/usr/local/bin
-
-FROM scratch
+FROM registry.suse.com/bci/bci-base:15.6
 
 ENV SSL_CERT_DIR /etc/rancher/ssl
 
-COPY --from=builder /chroot /
+RUN zypper -n update && \
+    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar openssh-clients && \
+    zypper -n clean -a && \
+    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
+
+RUN useradd -u 1000 machine
 
 RUN mkdir -p .docker/machine/machines /etc/rancher/ssl /home/machine && \
     chown -R machine /etc/rancher/ssl && \
     chown -R machine /home/machine
 
+COPY download_driver.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/download_driver.sh
+
+COPY rancher-machine entrypoint.sh /usr/local/bin/
+RUN chmod 0777 /usr/local/bin
+
 USER 1000
+WORKDIR /home/machine
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/47853

This reverts commit 3d1d808b6703079fe78bd7214db059f41e71c20b.

#252 introduced a change which resulted in failures to download external node drivers, receiving the following message:
```
Downloading driver from ...
Doing /etc/rancher/ssl
ls: docker-machine-driver-*: No such file or directory
downloaded file  failed sha256 checksum
download of driver from ... failed
```
The Rancher CAs are mounted into the pod, and the following is performed in order to use the CAs: https://github.com/rancher/machine/blob/master/package/download_driver.sh#L5-L13