### PR TITLE
Re-add "Change the generated image to `bci-busybox:15.6` (#252)" with additional fixes

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,25 +1,39 @@
-FROM registry.suse.com/bci/bci-base:15.6
+ARG BCI_VERSION=15.6
+
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+# Creates the base dir for the target image, and hydrates it with the
+# final image's contents.
+RUN mkdir /chroot
+COPY --from=final / /chroot/
+
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n rm busybox-less && \
+    zypper --installroot /chroot -n install \
+        git-core curl mkisofs openssh-clients openssl patterns-base-fips && \
+    zypper -n clean -a && \
+    rm -rf /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+RUN useradd -u 1000 machine
+RUN cp /etc/passwd /chroot/etc/passwd
+
+COPY download_driver.sh /chroot/usr/local/bin/
+RUN chmod +x /chroot/usr/local/bin/download_driver.sh
+
+COPY rancher-machine entrypoint.sh /chroot/usr/local/bin/
+RUN chmod 0755 /chroot/usr/local/bin
+
+FROM scratch
 
 ENV SSL_CERT_DIR /etc/rancher/ssl
 
-RUN zypper -n update && \
-    zypper -n install git-core curl ca-certificates unzip mkisofs xz gzip sed tar openssh-clients && \
-    zypper -n clean -a && \
-    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
-
-RUN useradd -u 1000 machine
+COPY --from=builder /chroot /
 
 RUN mkdir -p .docker/machine/machines /etc/rancher/ssl /home/machine && \
     chown -R machine /etc/rancher/ssl && \
     chown -R machine /home/machine
 
-COPY download_driver.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/download_driver.sh
-
-COPY rancher-machine entrypoint.sh /usr/local/bin/
-RUN chmod 0777 /usr/local/bin
-
 USER 1000
-WORKDIR /home/machine
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -32,8 +32,10 @@ COPY --from=builder /chroot /
 
 RUN mkdir -p .docker/machine/machines /etc/rancher/ssl /home/machine && \
     chown -R machine /etc/rancher/ssl && \
-    chown -R machine /home/machine
+    chown -R machine /home/machine && \
+    chown machine /usr/local/bin
 
 USER 1000
+WORKDIR /home/machine
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/46100

**This PR includes:**
- All changes from https://github.com/rancher/machine/pull/252
- The fix for the permissions issue that causes node driver downloads to fail. [issue](https://github.com/rancher/rancher/issues/47853) 


**More information about the node-driver-downloading issue:**

When provisioning an RKE2/K3s node-driver cluster in Rancher, Rancher deploys a Job that runs the `rancher-machine` container. This container first downloads the external node driver, then invokes the `rancher-machine` binary to create the VM in the cloud ([code](https://github.com/rancher/machine/blob/master/package/entrypoint.sh#L28-L39)). The container runs with a security context configured as `runAsUser: 1000` and `runAsGroup: 1000`. In the original PR, the Job fails to [move the downloaded node driver to /usr/local/bin/](https://github.com/rancher/machine/blob/master/package/download_driver.sh#L51) due to a permissions issue. 

 
The fix for this issue involves changing the ownership of `/usr/local/bin` to the `machine` user (UID 1000). This allows the running container to move the node driver to `/usr/local/bin` while being unable to modify any existing binaries which are owned by `root`. Additionally, the security context set on the container ensures that the process runs as a non-root user.

**Dev validate**

We can use `-e CATTLE_MACHINE_PROVISION_IMAGE=$IMAGE` in the `docker run` command to override the `rancher-machine` image used by the v1 provisioning framework.

The Docker image built from this PR was tested in Rancher by provisioning a node-driver Linode K3s cluster, and the cluster was successfully provisioned.

Below are the pod logs:
```
Downloading driver from https://<IP>/assets/docker-machine-driver-linode
Doing /etc/rancher/ssl
docker-machine-driver-linode
docker-machine-driver-linode: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
Running pre-create checks...
(aaaa-jiaqi-ta-qbwvq-vrsrl) Generating a secure disposable linode-root-pass...
Creating machine...
(aaaa-jiaqi-ta-qbwvq-vrsrl) Creating Linode machine instance...
(aaaa-jiaqi-ta-qbwvq-vrsrl) Waiting for Machine Running...
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with ubuntu(systemd)...
Provisioning with custom install script via SSH, not installing Docker...
```








