### PR TITLE
[RKE] [RHEL]: install openssl and openssh with curl

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -43,6 +43,9 @@ func init() {
 func NewRedHatProvisioner(osReleaseID string, d drivers.Driver) *RedHatProvisioner {
 	systemdProvisioner := NewSystemdProvisioner(osReleaseID, d)
 	systemdProvisioner.SSHCommander = RedHatSSHCommander{Driver: d}
+	// need to install "openssh" and "openssl" together with "curl" since curl installation was causing "openssl"
+	// to auto-upgrade and because of that "openssh" version was out of sync with "openssl" which was causing ssh failure
+	systemdProvisioner.Packages = []string{"curl openssh openssl"}
 	return &RedHatProvisioner{
 		systemdProvisioner,
 	}


### PR DESCRIPTION
needed to keep openssh and openssl versions in sync

issue: https://github.com/rancher/rancher/issues/48143 / https://github.com/rancher/rancher/issues/48193

problem: curl is installed before installing docker and curl installation on rhel was causing openssl to autoupgrade. 
```
$ sudo -E yum install -y curl

Transaction Summary
=========================================================================================================================================================
Install  2 Packages
Upgrade  4 Packages

Total download size: 4.6 M
Downloading Packages:
(1/6): openssl-fips-provider-3.0.7-6.el9_5.x86_64.rpm                                                                    186 kB/s | 9.4 kB     00:00    
(2/6): curl-7.76.1-31.el9.x86_64.rpm                                                                                     4.6 MB/s | 297 kB     00:00    
(3/6): openssl-fips-provider-so-3.0.7-6.el9_5.x86_64.rpm                                                                 7.6 MB/s | 577 kB     00:00    
(4/6): libcurl-7.76.1-31.el9.x86_64.rpm                                                                                  8.7 MB/s | 286 kB     00:00    
(5/6): openssl-3.2.2-6.el9_5.x86_64.rpm                                                                                   37 MB/s | 1.4 MB     00:00    
(6/6): openssl-libs-3.2.2-6.el9_5.x86_64.rpm                                                                              48 MB/s | 2.1 MB     00:00    
---------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                     31 MB/s | 4.6

```

which was causing ssh failure because of which provisioning was failing
```
$ journalctl -u sshd.service
........
......OpenSSL version mismatch. Built against 30000070, you have 30200020
......Main process exited, code=exited, status=255/EXCEPTION
.......

```
updated the first install so that following command is executed.

`$ sudo -E yum install -y curl openssh openssl`
