### PR TITLE
handle cloud-init recoverable failure exit status by swallowing specific exit code

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -272,8 +272,10 @@ func checkDaemonUp(p Provisioner, dockerPort int) func() bool {
 
 // waitForCloudInit runs `cloud-init status --wait` on the node in order to wait for the node to be ready before
 // continuing execution.
+// it also swallows the "bad" exit code that can be returned but is in reality just alerting us that there were benign
+// errors during cloud-init: https://docs.cloud-init.io/en/24.1/explanation/failure_states.html#recoverable-failure
 func waitForCloudInit(p Provisioner) error {
-	_, err := p.SSHCommand("sudo cloud-init status --wait")
+	_, err := p.SSHCommand(`sudo bash -c 'cloud-init status --wait >/dev/null || if [ $? == 2 ]; then true ; fi'`)
 	if err != nil {
 		return fmt.Errorf("failed to wait for cloud-init: %w", err)
 	}


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/48052

The issue comes down to the fact that `cloud-init` now exits with code 2 if there are errors during provisioning. After debugging why the issue occurred - cloud-init can now give us nice long errors that we can safely ignore most of the time due to the fact that these errors are considered "recoverable" (example at bottom).

Initially I was going to parse the command output for `cloud-init status --wait --format json` but then I subsequently found out that format flag is really new as well which would cause cloud-init to exit with a bad status code for a different reason. Rather than try and handle that since it may not be safe to completely ignore that (or compare the error to a static string since it may change) I just implemented a simple bypass for the _specific_ exit code related to recoverable errors. 

exmaple output when there is a recoverable error, in this case a group already existed in the image:
```
$ cloud-init status
status: done
$ cloud-init status --wait

status: done
$ echo $?
2
$ cloud-init status --format json
{
  "boot_status_code": "enabled-by-generator",
  "datasource": "nocloud",
  "detail": "DataSourceNoCloud [seed=/dev/sr0]",
  "errors": [],
  "extended_status": "degraded done",
  "init": {
    "errors": [],
    "finished": 11.17,
    "recoverable_errors": {
      "WARNING": [
        "Skipping creation of existing group 'staff'"
      ]
    },
    "start": 9.88
  },
  "init-local": {
    "errors": [],
    "finished": 7.51,
    "recoverable_errors": {},
    "start": 6.67
  },
  "last_update": "Thu, 01 Jan 1970 00:00:14 +0000",
  "modules-config": {
    "errors": [],
    "finished": 12.18,
    "recoverable_errors": {},
    "start": 11.89
  },
  "modules-final": {
    "errors": [],
    "finished": 14.41,
    "recoverable_errors": {},
    "start": 14.3
  },
  "recoverable_errors": {
    "WARNING": [
      "Skipping creation of existing group 'staff'"
    ]
  },
  "stage": null,
  "status": "done"
}
```