### PR TITLE
Make failed download print error

### DIFF
--- a/package/download_driver.sh
+++ b/package/download_driver.sh
@@ -12,7 +12,7 @@ if [ -x "$(command -v c_rehash)" ]; then
   c_rehash
 fi
 
-curl -sSLO "$1"
+curl -sLO "$1" || echo "Curl failed with error code $?"
 driver_file=$(ls $driver_prefix*)
 driver_name=$(echo "$driver_file" | sed -e "s/^$driver_prefix//" -e "s/[-_\.].*$//")
 driver_path=driver_dir/$driver_prefix$driver_name

--- a/package/download_driver.sh
+++ b/package/download_driver.sh
@@ -12,7 +12,7 @@ if [ -x "$(command -v c_rehash)" ]; then
   c_rehash
 fi
 
-curl -sLO "$1"
+curl -sSLO "$1"
 driver_file=$(ls $driver_prefix*)
 driver_name=$(echo "$driver_file" | sed -e "s/^$driver_prefix//" -e "s/[-_\.].*$//")
 driver_path=driver_dir/$driver_prefix$driver_name


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/49788 & https://github.com/rancher/rancher/issues/49790
The machine driver invocation starts by downloading the machine driver binary from Rancher server.
This download may fail due to a variety of reasons. This commit adds an option to curl to print the error message in case of a failed download for easier troubleshooting and debugging.