### PR TITLE
External node drivers cloud-config user data is not handled the same as in-tree drivers

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -415,6 +415,8 @@ func updateUserdataFile(driverOpts *rpcdriver.RPCFlags, machineName, hostname, u
 	if userdataFile == "" {
 		// Always convert to cloud config if user data is not provided
 		userdataContent = []byte("#cloud-config")
+	} else if strings.HasPrefix(userdataFile, "#cloud-config") {
+		userdataContent = []byte(userdataFile)
 	} else {
 		userdataContent, err = os.ReadFile(userdataFile)
 		if err != nil {


### PR DESCRIPTION
Internal node drivers (see vsphere) handle the passing of "#cloud-config" as a file, but there is no mechanism currently to do the same for external node drivers.

When building the oxide node driver: https://github.com/oxidecomputer/rancher-machine-driver-oxide and working with #cloud-config, the passing of the #cloud-config within the driver is assumed to be coming in as a file. But the file injection mechanism is only wired up for internal drivers: https://github.com/rancher/rancher/blob/73c4db122c2141d56bbea47f7e63025c30cdb6e0/pkg/controllers/management/drivers/nodedriver/machine_driver.go#L196-L202 

Rancher Machine would give errors like this when giving the file contents of cloud-config:
```
could not alter cloud-init file: #cloud-config
runcmd:
#etc...
```

This PR fixes the symptom of the issue, in that the file contents is passed. The contents should be prefixed with `#cloud-config`

rancher/rancher could go further and expose these for file handling for node drivers as an annotation? https://github.com/rancher/rancher/blob/73c4db122c2141d56bbea47f7e63025c30cdb6e0/pkg/controllers/management/drivers/nodedriver/machine_driver.go#L32 and https://github.com/rancher/rancher/blob/73c4db122c2141d56bbea47f7e63025c30cdb6e0/pkg/controllers/management/node/controller.go#L56
specifically updating here: https://github.com/rancher/rancher/blob/73c4db122c2141d56bbea47f7e63025c30cdb6e0/pkg/controllers/management/drivers/nodedriver/machine_driver.go#L196-L202
and here: https://github.com/rancher/rancher/blob/7f16b596120dd382ce6e9ed0baf83bc23f633054/pkg/controllers/capr/machineprovision/controller.go#L811-L837