### PR TITLE
fix nesting for GHA workflow trigger

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-    # For manual scans.
-    workflow_dispatch:
+  # For manual scans.
+  workflow_dispatch:
 
 jobs:
   fossa:


### PR DESCRIPTION
## Description

Just a tiny fix to the workflow syntax here. The `workflow_dispatch` trigger is nested one level too far, so it's not actually valid this way.