### PR TITLE
fix(vmwarevsphere): use WaitForIP instead of WaitForNetIP to fix hang with multiple NICs

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -186,31 +186,22 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	configuredMacIPs, err := vm.WaitForNetIP(d.getCtx(), false)
+	// WaitForNetIP blocks until ALL NICs have an IP, which hangs indefinitely
+	// when multiple networks are configured but only one has DHCP.
+	// WaitForIP watches guest.ipAddress (the primary IP reported by VMware Tools)
+	// and works correctly regardless of how many NICs the VM has.
+	ip, err := vm.WaitForIP(d.getCtx(), true)
 	if err != nil {
 		return "", err
 	}
 
-	for _, ips := range configuredMacIPs {
-		if len(ips) >= 0 {
-			// Prefer IPv4 address, but fall back to first/IPv6
-			preferredIP := ips[0]
-			for _, ip := range ips {
-				// In addition to non IPv4 addresses, try to filter
-				// out link local addresses and the default address of
-				// the Docker0 bridge
-				netIP := net.ParseIP(ip)
-				if netIP.To4() != nil && netIP.IsGlobalUnicast() && !netIP.Equal(net.ParseIP(dockerBridgeIP)) {
-					preferredIP = ip
-					break
-				}
-			}
-			d.IPAddress = preferredIP // cache
-			return preferredIP, nil
-		}
+	netIP := net.ParseIP(ip)
+	if netIP == nil || netIP.To4() == nil || !netIP.IsGlobalUnicast() || netIP.Equal(net.ParseIP(dockerBridgeIP)) {
+		return "", errors.New("No valid IP despite waiting for one - check DHCP status")
 	}
 
-	return "", errors.New("No IP despite waiting for one - check DHCP status")
+	d.IPAddress = ip
+	return ip, nil
 }
 
 func (d *Driver) GetState() (state.State, error) {


### PR DESCRIPTION
## Problem

When a node pool is configured with **two network interfaces**, machine creation hangs indefinitely at:

```
Waiting for VMware Tools to come online...
```

## Root cause

`GetIP()` calls `vm.WaitForNetIP(ctx, false)` (govmomi), which monitors the `guest.net` property and only returns when **all** NICs have reported an IP address:

```go
for _, ips := range macs {
    if len(ips) == 0 {
        return false // keeps waiting
    }
}
```

This hangs when the VM has multiple network adapters but only one has a DHCP server — a common setup where a secondary NIC is used for storage or internal traffic with no DHCP. VMware Tools reports the primary IP in vCenter, but `WaitForNetIP` never completes because the second NIC has no IP.

## Fix

Replace `WaitForNetIP` with `WaitForIP`, which monitors `guest.ipAddress` (the primary IPv4 address reported by VMware Tools) and returns as soon as one IPv4 address is available, regardless of how many NICs the VM has.

This also removes a `len(ips) >= 0` check that was always true (slice length is never negative) and could mask an empty-slice index panic.

## Test

- Node pool with **1 network**: works before and after
- Node pool with **2 networks** (only one with DHCP): hangs before fix, completes after fix