### PR TITLE
fix(libmachine/provision): dropped error

### DIFF
--- a/libmachine/provision/photonos.go
+++ b/libmachine/provision/photonos.go
@@ -170,7 +170,9 @@ func (provisioner *PhotonOSProvisioner) Provision(swarmOptions swarm.Options, au
 	}
 
 	log.Debug("Configuring swarm")
-	err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions)
+	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
+		return err
+	}
 
 	// enable in systemd
 	log.Debug("Enabling docker in systemd")


### PR DESCRIPTION
This fixes a dropped `err` variable in `libmachine/provision`.