### PR TITLE
[2.13] fix push job to push to prime/stg registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,20 @@ on:
     tags:
       - '*'
 
-env:
-  IMAGE: rancher/machine
-
 jobs:
-  build-push-images:
+  create-draft:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # needed for the Vault authentication
+      contents: write
+    steps:
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create -R "${GITHUB_REPOSITORY}" --draft --generate-notes "${GITHUB_REF_NAME}"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [create-draft]
     strategy:
       fail-fast: true
       matrix:
@@ -21,135 +26,97 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Setup Environment Variables
-        run: |
-          echo "GOOS=${{ matrix.os }}"     >> "$GITHUB_ENV"
-          echo "GOARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "ARCH=${{ matrix.arch }}"   >> "$GITHUB_ENV"
-      - name: Clean up
-        run: ./scripts/clean
-      - name: Compile Go
-        run: ./scripts/build
-      - name: Stage artifacts
-        run: ./scripts/package
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build binary
+        run: make build ARCH=${{ matrix.arch }}
+      - name: Package artifacts
+        run: make package ARCH=${{ matrix.arch }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "rancher-machine-${{ matrix.arch }}.tar.gz"
           path: "dist/artifacts/rancher-machine-${{ matrix.arch }}.tar.gz"
           if-no-files-found: error
           overwrite: true
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: |
-            latest=false
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Load Secrets from Vault
-        uses: rancher-eio/read-vault-secrets@main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: package
-          push: true
-          tags: "${{ steps.meta.outputs.tags }}"
-          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
-          labels: "${{ steps.meta.outputs.labels }}"
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: "digests-${{ matrix.os }}-${{ matrix.arch }}"
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 7
-          overwrite: true
 
-  merge:
+  publish:
     runs-on: ubuntu-latest
-    needs:
-      - build-push-images
+    needs: [create-draft]
     permissions:
       contents: read
-      id-token: write # needed for the Vault authentication
+      id-token: write # required for cosign signing
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: |
-            latest=false
       - name: Load Secrets from Vault
-        uses: rancher-eio/read-vault-secrets@main
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # main
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | PRIME_STG_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | PRIME_STG_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | PRIME_STG_REGISTRY_PASSWORD
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Build and push image to DockerHub and Prime Staging Registry
+        uses: rancher/ecm-distro-tools/actions/publish-image@dccc58c2e8e9c059aeab6229b70d2f0b1e977625 # master
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          image: machine
+          tag: ${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
 
-  create-release:
+          public-registry: docker.io
+          public-repo: rancher
+          public-username: ${{ env.DOCKER_USERNAME }}
+          public-password: ${{ env.DOCKER_PASSWORD }}
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_STG_REGISTRY }}
+          prime-repo: rancher
+          prime-make-target: push-prime-image
+          prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
+      - name: Build and push image to Prime Prod Registry
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        uses: rancher/ecm-distro-tools/actions/publish-image@dccc58c2e8e9c059aeab6229b70d2f0b1e977625 # master
+        with:
+          image: machine
+          tag: ${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
+
+          push-to-public: false
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_REGISTRY }}
+          prime-repo: rancher
+          prime-make-target: push-prime-image
+          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+
+  finalize:
     runs-on: ubuntu-latest
     needs:
-      - merge
+      - build
+      - publish
     permissions:
-      contents: write # needed for creating the GH release
+      contents: write # Publish the draft release
+      id-token: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Download assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/assets
           pattern: rancher-machine-*.tar.gz
           merge-multiple: true
-      - name: (for testing) check files
-        run: ls -l /tmp/assets
-      - name: Create GH release
-        run: gh release create ${{ github.ref_name }} --verify-tag --generate-notes /tmp/assets/rancher-machine-*.tar.gz
+      - name: Upload binary assets to release
+        run: gh release upload -R "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}" /tmp/assets/rancher-machine-*.tar.gz
+      - name: Publish the release
+        run: gh release edit -R "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}" --draft=false


### PR DESCRIPTION
release/v2.13 doesn't contain the "new" secure supply chain flows in it since it was based on an older tag - this PR brings it inline with main and release/v2.14