### PR TITLE
[2.14] bump golang to latest patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/machine
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 replace github.com/urfave/cli => github.com/urfave/cli v1.11.1-0.20151120215642-0302d3914d2a // newer versions of this will break the rpc binding code
 


### PR DESCRIPTION
bumping go version to 1.25.11 so that we can get some CVEs nixed!
