### PR TITLE
fix renovate by granting id-token permission

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,13 +12,17 @@ on:
         required: false
         default: "false"
         type: string
-  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
+  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge), only on weekdays
   schedule:
-    - cron: '30 4,6 * * *'
+    - cron: '30 4,6 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate.yml@c88cbe41a49d02648b9bf83aa5a64902151323fa # release
+    uses: rancher/renovate-config/.github/workflows/renovate.yml@b05a94b6ef60bae74e161e05dbd108c579ee2183 # release
     with:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}


### PR DESCRIPTION
renovate hasn't been running for quite a while - after some looking into it it seems like its due to the fact that we are missing the id-token permission which lines up with the error we're seeing.

[example failure](https://github.com/rancher/machine/actions/runs/27261675685/job/80508663329)
