### PR TITLE
Relax vSphere delete prechecks

### DIFF
--- a/drivers/vmwarevsphere/create.go
+++ b/drivers/vmwarevsphere/create.go
@@ -72,6 +72,28 @@ func (d *Driver) preCreate() error {
 	return nil
 }
 
+// preRemove creates the minimum vSphere context needed for delete operations.
+// Unlike preCreate, it must not validate current placement settings such as
+// networks, hostsystem, or resource pool because a VM can still be deleted even
+// after those values become stale in the machine config.
+func (d *Driver) preRemove() error {
+	c, err := d.getSoapClient()
+	if err != nil {
+		return err
+	}
+
+	d.finder = find.NewFinder(c.Client, true)
+
+	d.datacenter, err = d.finder.DatacenterOrDefault(d.getCtx(), d.Datacenter)
+	if err != nil {
+		return err
+	}
+	log.Infof("Using datacenter %s", d.datacenter.InventoryPath)
+	d.finder.SetDatacenter(d.datacenter)
+
+	return nil
+}
+
 // postCreate adds additional VM configuration,
 // parses, applies, and creates the cloudInit ISO
 // and adds tags and custom attributes

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -457,7 +457,7 @@ func (d *Driver) Remove() error {
 		return nil
 	}
 
-	if err := d.preCreate(); err != nil {
+	if err := d.preRemove(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- add a delete-specific vSphere initialization path for VM removal
- stop validating current network, hostsystem, and resource pool settings during delete
- keep the datacenter/finder setup needed for VM lookup and ISO cleanup

## Why
Scale-down of an existing VMware-backed machine can fail to delete the backing VM when the current machine configuration has gone stale, for example when `hostsystem` still points at an ESX host that has been removed. Deleting an existing VM should not depend on current placement settings that are only required for create-time decisions.

Fixes rancher/rancher#55800

## Testing
- `go test ./drivers/vmwarevsphere/...`