### PR TITLE
add http_put_response_hop_limit in amazonec2_config

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -48,6 +48,7 @@ const (
 	defaultSSHUser              = "ubuntu"
 	defaultSpotPrice            = "0.50"
 	defaultBlockDurationMinutes = 0
+	defaultHttpPutResponseHopLimit = 2
 	charset                     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	ec2VolumeResource           = "volume"
 	ec2NetworkInterfaceResource = "network-interface"
@@ -150,7 +151,7 @@ type Driver struct {
 	// Metadata Options
 	HttpEndpoint            string
 	HttpTokens              string
-	HttpPutResponseHopLimit int64
+	HttpPutResponseHopLimit *int64
 
 	// Enables or disables the IPv6 endpoint for the instance metadata service.
 	// Options: enabled, disabled
@@ -362,6 +363,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "amazonec2-http-put-response-hop-limit",
 			Usage:  "The desired HTTP PUT response hop limit for instance metadata requests (1-64).",
 			EnvVar: "AWS_HTTP_PUT_RESPONSE_HOP_LIMIT",
+			Value:  defaultHttpPutResponseHopLimit,
 		},
 		mcnflag.IntFlag{
 			Name: "amazonec2-ipv6-address-count",
@@ -548,7 +550,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		if httpPutResponseHopLimit < 1 || httpPutResponseHopLimit > 64 {
 			return errorInvalidValueForHTTPPutResponseHopLimit
 		}
-		d.HttpPutResponseHopLimit = httpPutResponseHopLimit
+		d.HttpPutResponseHopLimit = aws.Int64(httpPutResponseHopLimit)
 	}
 
 	if d.Ipv6AddressOnly && d.Ipv6AddressCount < 1 {
@@ -885,8 +887,8 @@ func (d *Driver) innerCreate() error {
 			req.MetadataOptions.HttpProtocolIpv6 = aws.String(d.HttpProtocolIpv6)
 		}
 
-		if d.HttpPutResponseHopLimit != 0 {
-			req.MetadataOptions.HttpPutResponseHopLimit = aws.Int64(d.HttpPutResponseHopLimit)
+		if d.HttpPutResponseHopLimit != nil {
+			req.MetadataOptions.HttpPutResponseHopLimit = d.HttpPutResponseHopLimit
 		}
 
 		if d.BlockDurationMinutes != 0 {
@@ -989,8 +991,8 @@ func (d *Driver) innerCreate() error {
 			req.MetadataOptions.HttpProtocolIpv6 = aws.String(d.HttpProtocolIpv6)
 		}
 
-		if d.HttpPutResponseHopLimit != 0 {
-			req.MetadataOptions.HttpPutResponseHopLimit = aws.Int64(d.HttpPutResponseHopLimit)
+		if d.HttpPutResponseHopLimit != nil {
+			req.MetadataOptions.HttpPutResponseHopLimit = d.HttpPutResponseHopLimit
 		}
 
 		res, err := d.getClient().RunInstances(&req)

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -88,6 +88,7 @@ var (
 	errorInvalidValueForHTTPToken              = errors.New("httpToken must be either optional or required")
 	errorInvalidValueForHTTPEndpoint           = errors.New("httpEndpoint must be either enabled or disabled")
 	errorInvalidValueForHTTPProtocolIpv6       = errors.New("httpProtocolIpv6 must be either enabled or disabled")
+	errorInvalidValueForHTTPPutResponseHopLimit = errors.New("httpPutResponseHopLimit must be between 1 and 64")
 	errorInvalidValueForIpv6AddressCount       = errors.New("ipv6AddressCount must be greater than zero when Ipv6AddressOnly is true")
 )
 
@@ -147,8 +148,9 @@ type Driver struct {
 	kmsKeyId                *string
 	bdmList                 []*ec2.BlockDeviceMapping
 	// Metadata Options
-	HttpEndpoint string
-	HttpTokens   string
+	HttpEndpoint            string
+	HttpTokens              string
+	HttpPutResponseHopLimit int64
 
 	// Enables or disables the IPv6 endpoint for the instance metadata service.
 	// Options: enabled, disabled
@@ -357,6 +359,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  "disabled",
 		},
 		mcnflag.IntFlag{
+			Name:   "amazonec2-http-put-response-hop-limit",
+			Usage:  "The desired HTTP PUT response hop limit for instance metadata requests (1-64).",
+			EnvVar: "AWS_HTTP_PUT_RESPONSE_HOP_LIMIT",
+		},
+		mcnflag.IntFlag{
 			Name: "amazonec2-ipv6-address-count",
 			Usage: "The number of IPv6 addresses to assign to the network interface (default: 0)." +
 				" Must be greater than zero when amazonec2-ipv6-address-only is true.",
@@ -534,6 +541,14 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 			return errorInvalidValueForHTTPProtocolIpv6
 		}
 		d.HttpProtocolIpv6 = httpProtocolIpv6
+	}
+
+	httpPutResponseHopLimit := int64(flags.Int("amazonec2-http-put-response-hop-limit"))
+	if httpPutResponseHopLimit != 0 {
+		if httpPutResponseHopLimit < 1 || httpPutResponseHopLimit > 64 {
+			return errorInvalidValueForHTTPPutResponseHopLimit
+		}
+		d.HttpPutResponseHopLimit = httpPutResponseHopLimit
 	}
 
 	if d.Ipv6AddressOnly && d.Ipv6AddressCount < 1 {
@@ -870,6 +885,10 @@ func (d *Driver) innerCreate() error {
 			req.MetadataOptions.HttpProtocolIpv6 = aws.String(d.HttpProtocolIpv6)
 		}
 
+		if d.HttpPutResponseHopLimit != 0 {
+			req.MetadataOptions.HttpPutResponseHopLimit = aws.Int64(d.HttpPutResponseHopLimit)
+		}
+
 		if d.BlockDurationMinutes != 0 {
 			req.InstanceMarketOptions.SpotOptions.BlockDurationMinutes = &d.BlockDurationMinutes
 		}
@@ -968,6 +987,10 @@ func (d *Driver) innerCreate() error {
 
 		if d.HttpProtocolIpv6 != "" {
 			req.MetadataOptions.HttpProtocolIpv6 = aws.String(d.HttpProtocolIpv6)
+		}
+
+		if d.HttpPutResponseHopLimit != 0 {
+			req.MetadataOptions.HttpPutResponseHopLimit = aws.Int64(d.HttpPutResponseHopLimit)
 		}
 
 		res, err := d.getClient().RunInstances(&req)


### PR DESCRIPTION

This PR adds support for configuring the EC2 Instance Metadata Service (IMDS) `http_put_response_hop_limit` option in the Amazon EC2 node driver.

### Related
[#56145](https://github.com/rancher/rancher/issues/56145)
Related: [rancher/terraform-provider-rancher2#2327](https://github.com/rancher/terraform-provider-rancher2/issues/2327)

### Changes

- Added a new driver flag:

1.    `--amazonec2-http-put-response-hop-limit`
2.    Environment variable: `AWS_HTTP_PUT_RESPONSE_HOP_LIMIT`

- Added validation to ensure the value is within the supported AWS range of **1–64**.
- Stored the configured value in the driver configuration.
- Applied the value to EC2 `MetadataOptions.HttpPutResponseHopLimit` during instance creation.

### Why

Some workloads access the EC2 Instance Metadata Service (IMDS) from within Kubernetes pods. AWS uses the HTTP PUT response hop limit to control IMDS reachability, and the default value may prevent pods from accessing IMDS in certain networking configurations.

This change allows users to configure the hop limit when provisioning EC2 instances through Rancher, aligning this setting with the other IMDS metadata options already supported by the Amazon EC2 node driver.


