### PR TITLE
add auto-tag job to cut a new rc if master has changed

### DIFF
--- a/.github/workflows/daily-master-tag.yaml
+++ b/.github/workflows/daily-master-tag.yaml
@@ -1,0 +1,30 @@
+name: Daily Master Tag
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: daily-master-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master and tags
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Configure tagger
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Create tag when master changed
+        run: ./scripts/tag-rc-if-master-changed

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Subsequent tags from that branch would be `v0.15.0-rancher142.3`, `v0.15.0-ranch
 ### Automated master release candidates
 
 The daily `Daily Master Tag` workflow compares the current `master` commit with
-the latest Rancher tag. If they differ, it creates the next release-candidate
-tag; otherwise it exits without creating a tag.
+the latest supported Rancher tag matching `vX.Y.Z-rancherN` or
+`vX.Y.Z-rancherN-rc.M`. If they differ, it creates the next release-candidate
+tag; otherwise it exits without creating a tag. Other Rancher tag formats,
+including dotted patch tags, are ignored.
 
 ## Releasing a New Version
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Subsequent tags from that branch would be `v0.15.0-rancher142.3`, `v0.15.0-ranch
 | release/v2.14  | v2.14               |
 | release/v2.13  | v2.13               |
 
+### Automated master release candidates
+
+The daily `Daily Master Tag` workflow compares the current `master` commit with
+the latest Rancher tag. If they differ, it creates the next release-candidate
+tag; otherwise it exits without creating a tag.
+
 ## Releasing a New Version
 
 - **Prerequisite:**

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ New tags created from a release branch increment only the `.x` suffix of the ver
 For example, at the time of writing, `v0.15.0-rancher142.2` is the latest tag in the `release/v2.14` branch. 
 Subsequent tags from that branch would be `v0.15.0-rancher142.3`, `v0.15.0-rancher142.4`, and so on.
 
+Release candidates will also be created from release branches before the
+corresponding release is published. This is necessary because CVE fixes may
+require a high volume of releases.
+
 | Machine Branch | Rancher Releae line |
 |----------------|---------------------|
 | master         | main                |
@@ -53,8 +57,13 @@ Subsequent tags from that branch would be `v0.15.0-rancher142.3`, `v0.15.0-ranch
 The daily `Daily Master Tag` workflow compares the current `master` commit with
 the latest supported Rancher tag matching `vX.Y.Z-rancherN` or
 `vX.Y.Z-rancherN-rc.M`. If they differ, it creates the next release-candidate
-tag; otherwise it exits without creating a tag. Other Rancher tag formats,
-including dotted patch tags, are ignored.
+tag; otherwise it exits without creating a tag. Starting from a stable
+`vX.Y.Z-rancherN` tag, the first candidate is
+`vX.Y.Z-rancher(N+1)-rc.0`; each subsequent changed `master` commit increments
+the `rc` number. RC tags are for validating the next release from `master`;
+stable release tags continue to be created explicitly, and release branches
+continue to use the dotted patch suffix described above. Other Rancher tag
+formats, including dotted patch tags, are ignored by the automated RC tagger.
 
 ## Releasing a New Version
 

--- a/scripts/tag-rc-if-master-changed
+++ b/scripts/tag-rc-if-master-changed
@@ -3,6 +3,8 @@ set -euo pipefail
 
 remote="${1:-origin}"
 branch="${2:-master}"
+supported_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+-rancher[0-9]+(-rc\.[0-9]+)?$'
+rancher_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+-rancher'
 
 git check-ref-format --branch "$branch" >/dev/null
 git fetch --quiet --tags "$remote" "refs/heads/$branch:refs/remotes/$remote/$branch"
@@ -10,14 +12,17 @@ git fetch --quiet --tags "$remote" "refs/heads/$branch:refs/remotes/$remote/$bra
 target="refs/remotes/$remote/$branch"
 target_commit="$(git rev-parse "${target}^{commit}")"
 latest="$(
-  git tag --list |
-    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rancher[0-9]+(-rc\.[0-9]+)?$' |
-    sort -V |
+  git tag --list --sort=version:refname |
+    grep -E "$supported_tag_pattern" |
     tail -n1 || true
 )"
 
 if [[ -z "$latest" ]]; then
-  echo "No matching Rancher tags found" >&2
+  if git tag --list | grep -E "$rancher_tag_pattern" >/dev/null; then
+    echo "Rancher tags found, but none match the supported format" >&2
+  else
+    echo "No Rancher tags found" >&2
+  fi
   exit 1
 fi
 
@@ -42,7 +47,7 @@ if git ls-remote --exit-code --tags "$remote" "refs/tags/$next" >/dev/null 2>&1;
 fi
 
 echo "Latest tag:  $latest"
-echo "Master commit: $target_commit"
+echo "$branch commit: $target_commit"
 echo "Next tag:    $next"
 
 git tag --no-sign -a "$next" "$target_commit" -m "Release candidate $next"

--- a/scripts/tag-rc-if-master-changed
+++ b/scripts/tag-rc-if-master-changed
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+branch="${2:-master}"
+
+git check-ref-format --branch "$branch" >/dev/null
+git fetch --quiet --tags "$remote" "refs/heads/$branch:refs/remotes/$remote/$branch"
+
+target="refs/remotes/$remote/$branch"
+target_commit="$(git rev-parse "${target}^{commit}")"
+latest="$(
+  git tag --list |
+    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rancher[0-9]+(-rc\.[0-9]+)?$' |
+    sort -V |
+    tail -n1 || true
+)"
+
+if [[ -z "$latest" ]]; then
+  echo "No matching Rancher tags found" >&2
+  exit 1
+fi
+
+latest_commit="$(git rev-parse "${latest}^{commit}")"
+if [[ "$latest_commit" == "$target_commit" ]]; then
+  echo "$branch is unchanged since $latest"
+  exit 0
+fi
+
+if [[ "$latest" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+-rancher)([0-9]+)-rc\.([0-9]+)$ ]]; then
+  next="${BASH_REMATCH[1]}${BASH_REMATCH[2]}-rc.$((BASH_REMATCH[3] + 1))"
+elif [[ "$latest" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+-rancher)([0-9]+)$ ]]; then
+  next="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))-rc.0"
+else
+  echo "Unexpected tag: $latest" >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code --tags "$remote" "refs/tags/$next" >/dev/null 2>&1; then
+  echo "Tag already exists: $next" >&2
+  exit 1
+fi
+
+echo "Latest tag:  $latest"
+echo "Master commit: $target_commit"
+echo "Next tag:    $next"
+
+git tag --no-sign -a "$next" "$target_commit" -m "Release candidate $next"
+git push "$remote" "refs/tags/$next"

--- a/scripts/test-tag-rc-if-master-changed
+++ b/scripts/test-tag-rc-if-master-changed
@@ -87,7 +87,7 @@ setup_repo v0.15.0-rancher150.1
 if run_tagger >"$tmpdir/dotted-tag-output" 2>&1; then
   fail "accepted unsupported dotted tag"
 fi
-grep -q 'No matching Rancher tags found' "$tmpdir/dotted-tag-output" ||
-  fail "dotted tag did not report that no matching tag was found"
+grep -q 'Rancher tags found, but none match the supported format' "$tmpdir/dotted-tag-output" ||
+  fail "dotted tag did not report its unsupported format"
 
 echo "tag-rc-if-master-changed tests passed"

--- a/scripts/test-tag-rc-if-master-changed
+++ b/scripts/test-tag-rc-if-master-changed
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tagger="$repo_root/scripts/tag-rc-if-master-changed"
+tmpdir="$(mktemp -d)"
+source_repo="$tmpdir/source"
+runner_repo="$tmpdir/runner"
+
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+setup_repo() {
+  local tag="$1"
+
+  rm -rf "$source_repo" "$runner_repo"
+  git init --quiet -b master "$source_repo"
+  git -C "$source_repo" config user.name tester
+  git -C "$source_repo" config user.email tester@example.com
+  git -C "$source_repo" config commit.gpgSign false
+  printf 'initial\n' > "$source_repo/README"
+  git -C "$source_repo" add README
+  git -C "$source_repo" commit --quiet -m initial
+  git -C "$source_repo" tag --no-sign -a "$tag" -m "$tag"
+
+  git clone --quiet "$source_repo" "$runner_repo"
+  git -C "$runner_repo" config user.name tester
+  git -C "$runner_repo" config user.email tester@example.com
+}
+
+change_master() {
+  local message="$1"
+
+  printf '%s\n' "$message" >> "$source_repo/README"
+  git -C "$source_repo" commit --quiet -am "$message"
+}
+
+run_tagger() {
+  (
+    cd "$runner_repo"
+    "$tagger"
+  )
+}
+
+assert_tag() {
+  local tag="$1"
+
+  test "$(git -C "$source_repo" tag --list "$tag")" = "$tag" ||
+    fail "missing tag $tag"
+}
+
+assert_tag_points_to_master() {
+  local tag="$1"
+  local tag_commit
+  local master_commit
+
+  tag_commit="$(git -C "$source_repo" rev-parse "${tag}^{commit}")"
+  master_commit="$(git -C "$source_repo" rev-parse master)"
+  test "$tag_commit" = "$master_commit" ||
+    fail "$tag does not point to master"
+}
+
+setup_repo v0.15.0-rancher149
+run_tagger
+test -z "$(git -C "$source_repo" tag --list 'v0.15.0-rancher150-rc.*')" ||
+  fail "created a tag for an unchanged master"
+
+change_master first-change
+run_tagger
+assert_tag v0.15.0-rancher150-rc.0
+assert_tag_points_to_master v0.15.0-rancher150-rc.0
+
+change_master second-change
+run_tagger
+assert_tag v0.15.0-rancher150-rc.1
+assert_tag_points_to_master v0.15.0-rancher150-rc.1
+
+run_tagger
+test "$(git -C "$source_repo" tag --list 'v0.15.0-rancher150-rc.*' | wc -l)" -eq 2 ||
+  fail "created a duplicate tag for an unchanged master"
+
+setup_repo v0.15.0-rancher150.1
+if run_tagger >"$tmpdir/dotted-tag-output" 2>&1; then
+  fail "accepted unsupported dotted tag"
+fi
+grep -q 'No matching Rancher tags found' "$tmpdir/dotted-tag-output" ||
+  fail "dotted tag did not report that no matching tag was found"
+
+echo "tag-rc-if-master-changed tests passed"


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55887

This PR just adds a script that looks at the "main" tags (e.g. v0.15.0-rancher150) and auto does an rc tag on the next and pushes it if the latest one does not match master.

Things to note:
- does not support .1, -patch, or the like (if we want that we should probably add support to the script per-branch as to not dirty the master branch too much)
- can be called via workflow OR schedule
